### PR TITLE
[SCM-202] Gateway 모듈 런타임 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-up dev-down dev-down-v staging-up staging-down staging-down-v check-prereqs roadmap-report agentic-new-run agentic-validate-run ci-build ci-test ci-contract ci-lint ci-security ci-migration ci-smoke migrate-dry-run migrate-validate rehearsal-run db-backup db-restore gradle-build gradle-test run-auth run-member new-rehearsal-record new-migration-report
+.PHONY: dev-up dev-up-gateway dev-down dev-down-v staging-up staging-down staging-down-v check-prereqs roadmap-report agentic-new-run agentic-validate-run ci-build ci-test ci-contract ci-lint ci-security ci-migration ci-smoke migrate-dry-run migrate-validate rehearsal-run db-backup db-restore gradle-build gradle-test run-auth run-member run-gateway new-rehearsal-record new-migration-report
 
 check-prereqs:
 	powershell -ExecutionPolicy Bypass -File .\scripts\check-prereqs.ps1
@@ -8,6 +8,9 @@ roadmap-report:
 
 dev-up:
 	powershell -ExecutionPolicy Bypass -File .\scripts\dev-up.ps1
+
+dev-up-gateway:
+	powershell -ExecutionPolicy Bypass -File .\scripts\dev-up.ps1 -WithGateway
 
 dev-down:
 	powershell -ExecutionPolicy Bypass -File .\scripts\dev-down.ps1
@@ -77,6 +80,9 @@ run-auth:
 
 run-member:
 	.\gradlew.bat :services:member:bootRun
+
+run-gateway:
+	.\gradlew.bat :services:gateway:bootRun
 
 new-rehearsal-record:
 	powershell -ExecutionPolicy Bypass -File .\scripts\new-rehearsal-record.ps1 -RehearsalId $(REHEARSAL_ID)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Copy-Item .env.example .env
 powershell -ExecutionPolicy Bypass -File .\scripts\dev-up.ps1
 ```
 
+Gateway까지 함께 실행하려면:
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\dev-up.ps1 -WithGateway
+```
+
 4. 로컬 통합 인프라 중지
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\scripts\dev-down.ps1
@@ -76,6 +81,7 @@ make ci-smoke
 서비스 빌드/실행(Gradle 멀티모듈):
 ```powershell
 .\gradlew.bat build
+.\gradlew.bat :services:gateway:bootRun
 .\gradlew.bat :services:auth:bootRun
 .\gradlew.bat :services:member:bootRun
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@ plugins {
 
 group = "kr.co.computermate.scmrft"
 version = "0.1.0-SNAPSHOT"
+ext {
+  springCloudVersion = "2025.0.0"
+}
 
 allprojects {
   group = rootProject.group
@@ -16,7 +19,8 @@ allprojects {
   }
 }
 
-def serviceProjects = subprojects.findAll { it.path != ":services" }
+def gatewayProjectPath = ":services:gateway"
+def serviceProjects = subprojects.findAll { it.path != ":services" && it.path != gatewayProjectPath }
 
 configure(serviceProjects) {
   apply plugin: "java"
@@ -42,4 +46,34 @@ configure(serviceProjects) {
 
 project(":services") {
   apply plugin: "java"
+}
+
+project(gatewayProjectPath) {
+  apply plugin: "java"
+  apply plugin: "org.springframework.boot"
+  apply plugin: "io.spring.dependency-management"
+
+  java {
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(21)
+    }
+  }
+
+  dependencyManagement {
+    imports {
+      mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+  }
+
+  dependencies {
+    implementation "org.springframework.cloud:spring-cloud-starter-gateway"
+    implementation "org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j"
+    implementation "org.springframework.boot:spring-boot-starter-actuator"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+    testImplementation "org.springframework.boot:spring-boot-starter-test"
+  }
+
+  tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+  }
 }

--- a/scripts/dev-up.ps1
+++ b/scripts/dev-up.ps1
@@ -1,5 +1,6 @@
 param(
-  [switch]$Build
+  [switch]$Build,
+  [switch]$WithGateway
 )
 
 $ErrorActionPreference = "Stop"
@@ -44,6 +45,21 @@ try {
   Write-Host "- Loki       : http://localhost:3100"
   Write-Host "- Tempo      : http://localhost:3200"
   Write-Host "- RabbitMQ   : http://localhost:15672"
+
+  if ($WithGateway) {
+    $gatewayBuildFile = Join-Path $root "services\\gateway\\build.gradle"
+    if (-not (Test-Path $gatewayBuildFile)) {
+      throw "Gateway module not found. expected: $gatewayBuildFile"
+    }
+
+    Write-Host "[INFO] Starting gateway with gradle bootRun in a new terminal..."
+    Start-Process powershell -ArgumentList @(
+      "-NoExit",
+      "-Command",
+      "Set-Location '$root'; .\gradlew.bat :services:gateway:bootRun"
+    ) | Out-Null
+    Write-Host "- Gateway    : http://localhost:8080"
+  }
 }
 finally {
   Pop-Location

--- a/services/README.md
+++ b/services/README.md
@@ -3,6 +3,7 @@
 MSA 서비스 코드를 관리합니다.
 
 ## 서비스 목록 및 기본 포트
+- `gateway` : 8080
 - `auth` : 8081
 - `member` : 8082
 - `board` : 8083
@@ -16,5 +17,6 @@ MSA 서비스 코드를 관리합니다.
 - 전체 빌드: `.\gradlew.bat build`
 - 전체 테스트: `.\gradlew.bat test`
 - 단일 서비스 실행 예시:
+  - `.\gradlew.bat :services:gateway:bootRun`
   - `.\gradlew.bat :services:auth:bootRun`
   - `.\gradlew.bat :services:member:bootRun`

--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /workspace
+
+COPY . .
+RUN ./gradlew.bat :services:gateway:bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+COPY --from=build /workspace/services/gateway/build/libs/*.jar /app/app.jar
+COPY infra/gateway/policies /app/infra/gateway/policies
+
+ENV GATEWAY_POLICY_PATH=/app/infra/gateway/policies/cutover-isolation.yaml
+ENV GATEWAY_EMERGENCY_STOP_ENABLED=false
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -1,0 +1,20 @@
+# Gateway Service
+
+SCM_RFT API Gateway 실행체입니다.
+
+## 역할
+- `/api/*` 라우팅 진입점
+- cutover 정책 기반 write 보호
+- emergency stop(503) 제어
+
+## 실행
+```powershell
+.\gradlew.bat :services:gateway:bootRun
+```
+
+## 정책 파일
+- 기본 경로: `infra/gateway/policies/cutover-isolation.yaml`
+- 환경변수로 재정의:
+  - `GATEWAY_POLICY_PATH`
+  - `GATEWAY_EMERGENCY_STOP_ENABLED`
+  - `GATEWAY_EMERGENCY_STOP_STATUS`

--- a/services/gateway/build.gradle
+++ b/services/gateway/build.gradle
@@ -1,0 +1,1 @@
+description = "SCM RFT gateway service"

--- a/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/GatewayApplication.java
+++ b/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/GatewayApplication.java
@@ -1,0 +1,11 @@
+package kr.co.computermate.scmrft.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GatewayApplication {
+  public static void main(String[] args) {
+    SpringApplication.run(GatewayApplication.class, args);
+  }
+}

--- a/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/GatewayHealthController.java
+++ b/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/GatewayHealthController.java
@@ -1,0 +1,15 @@
+package kr.co.computermate.scmrft.gateway;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/gateway/internal")
+public class GatewayHealthController {
+  @GetMapping("/health")
+  public Map<String, String> health() {
+    return Map.of("service", "gateway", "status", "ok");
+  }
+}

--- a/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/GatewayRouteConfiguration.java
+++ b/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/GatewayRouteConfiguration.java
@@ -1,0 +1,148 @@
+package kr.co.computermate.scmrft.gateway;
+
+import static org.springframework.cloud.gateway.support.RouteMetadataUtils.CONNECT_TIMEOUT_ATTR;
+import static org.springframework.cloud.gateway.support.RouteMetadataUtils.RESPONSE_TIMEOUT_ATTR;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import kr.co.computermate.scmrft.gateway.policy.GatewayPolicyDocument;
+import kr.co.computermate.scmrft.gateway.policy.GatewayPolicyLoader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import reactor.core.publisher.Mono;
+
+@Configuration
+public class GatewayRouteConfiguration {
+  @Bean
+  public GatewayPolicyDocument gatewayPolicy(GatewayPolicyLoader loader) {
+    return loader.load();
+  }
+
+  @Bean
+  public KeyResolver gatewayKeyResolver() {
+    return exchange -> {
+      String clientId = exchange.getRequest().getHeaders().getFirst("X-Client-Id");
+      if (clientId == null || clientId.isBlank()) {
+        clientId = "anonymous";
+      }
+      return Mono.just(clientId);
+    };
+  }
+
+  @Bean
+  public RedisRateLimiter globalRedisRateLimiter(GatewayPolicyDocument policy) {
+    int replenishRate = policy.getTrafficControl().getGlobalRateLimit().getRequestsPerSecond();
+    int burstCapacity = policy.getTrafficControl().getGlobalRateLimit().getBurstCapacity();
+    if (replenishRate <= 0) {
+      replenishRate = 1;
+    }
+    if (burstCapacity <= 0) {
+      burstCapacity = replenishRate;
+    }
+    return new RedisRateLimiter(replenishRate, burstCapacity);
+  }
+
+  @Bean
+  public RouteLocator gatewayRouteLocator(
+      RouteLocatorBuilder builder,
+      GatewayPolicyDocument policy,
+      RedisRateLimiter rateLimiter,
+      KeyResolver keyResolver
+  ) {
+    var routes = builder.routes();
+    int connectTimeout = policy.getDefaults().getConnectTimeoutMs();
+    Duration responseTimeout = Duration.ofMillis(policy.getDefaults().getRequestTimeoutMs());
+    int retries = Math.max(0, policy.getDefaults().getRetry().getAttempts());
+
+    for (GatewayPolicyDocument.RouteRule route : policy.getRoutes()) {
+      routes.route(route.getId(), predicate ->
+          predicate.path(route.getPath())
+              .filters(filters -> {
+                filters.requestRateLimiter(config ->
+                    config.setRateLimiter(rateLimiter).setKeyResolver(keyResolver)
+                );
+
+                if (policy.getDefaults().getRetry().isEnabled() && retries > 0) {
+                  filters.retry(config -> config.setRetries(retries));
+                }
+
+                filters.filter(writeProtectionFilter(route, policy.getCutoverSwitches().isBlockLegacyWrites()));
+                filters.setResponseHeader("X-SCM-Gateway-Route", route.getId());
+                return filters;
+              })
+              .metadata(CONNECT_TIMEOUT_ATTR, connectTimeout)
+              .metadata(RESPONSE_TIMEOUT_ATTR, responseTimeout)
+              .uri(route.getTarget())
+      );
+    }
+    return routes.build();
+  }
+
+  @Bean
+  public GlobalFilter emergencyStopFilter(
+      GatewayPolicyDocument policy,
+      @Value("${gateway.cutover.emergency-stop.enabled:false}") boolean emergencyStopEnabled,
+      @Value("${gateway.cutover.emergency-stop.http-status:0}") int configuredStatus
+  ) {
+    int statusCode = configuredStatus > 0
+        ? configuredStatus
+        : policy.getCutoverSwitches().getEmergencyStop().getHttpStatus();
+
+    return (exchange, chain) -> {
+      if (!emergencyStopEnabled) {
+        return chain.filter(exchange);
+      }
+      HttpStatus status = HttpStatus.resolve(statusCode);
+      if (status == null) {
+        status = HttpStatus.SERVICE_UNAVAILABLE;
+      }
+      ServerHttpResponse response = exchange.getResponse();
+      response.setStatusCode(status);
+      return response.setComplete();
+    };
+  }
+
+  private GatewayFilter writeProtectionFilter(GatewayPolicyDocument.RouteRule route, boolean blockLegacyWrites) {
+    if (route.getWriteProtection() == null || !route.getWriteProtection().isEnabledDuringCutover()) {
+      return (exchange, chain) -> chain.filter(exchange);
+    }
+
+    Set<HttpMethod> blockedMethods = route.getWriteProtection().getMethods().stream()
+        .map(this::toHttpMethodOrNull)
+        .filter(method -> method != null)
+        .collect(Collectors.toSet());
+
+    return (exchange, chain) -> {
+      HttpMethod method = exchange.getRequest().getMethod();
+      if (blockLegacyWrites && method != null && blockedMethods.contains(method)) {
+        exchange.getResponse().setStatusCode(HttpStatus.SERVICE_UNAVAILABLE);
+        return exchange.getResponse().setComplete();
+      }
+      return chain.filter(exchange);
+    };
+  }
+
+  private HttpMethod toHttpMethodOrNull(String method) {
+    if (method == null || method.isBlank()) {
+      return null;
+    }
+    try {
+      return HttpMethod.valueOf(method.toUpperCase(Locale.ROOT));
+    }
+    catch (IllegalArgumentException ignored) {
+      return null;
+    }
+  }
+}

--- a/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/policy/GatewayPolicyDocument.java
+++ b/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/policy/GatewayPolicyDocument.java
@@ -1,0 +1,349 @@
+package kr.co.computermate.scmrft.gateway.policy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class GatewayPolicyDocument {
+  private int policyVersion;
+  private String name;
+  private Defaults defaults = new Defaults();
+  private TrafficControl trafficControl = new TrafficControl();
+  private List<RouteRule> routes = new ArrayList<>();
+  private CutoverSwitches cutoverSwitches = new CutoverSwitches();
+
+  public int getPolicyVersion() {
+    return policyVersion;
+  }
+
+  public void setPolicyVersion(int policyVersion) {
+    this.policyVersion = policyVersion;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Defaults getDefaults() {
+    return defaults;
+  }
+
+  public void setDefaults(Defaults defaults) {
+    this.defaults = defaults;
+  }
+
+  public TrafficControl getTrafficControl() {
+    return trafficControl;
+  }
+
+  public void setTrafficControl(TrafficControl trafficControl) {
+    this.trafficControl = trafficControl;
+  }
+
+  public List<RouteRule> getRoutes() {
+    return routes;
+  }
+
+  public void setRoutes(List<RouteRule> routes) {
+    this.routes = routes;
+  }
+
+  public CutoverSwitches getCutoverSwitches() {
+    return cutoverSwitches;
+  }
+
+  public void setCutoverSwitches(CutoverSwitches cutoverSwitches) {
+    this.cutoverSwitches = cutoverSwitches;
+  }
+
+  public static class Defaults {
+    private int requestTimeoutMs = 5000;
+    private int connectTimeoutMs = 2000;
+    private Retry retry = new Retry();
+    private CircuitBreaker circuitBreaker = new CircuitBreaker();
+
+    public int getRequestTimeoutMs() {
+      return requestTimeoutMs;
+    }
+
+    public void setRequestTimeoutMs(int requestTimeoutMs) {
+      this.requestTimeoutMs = requestTimeoutMs;
+    }
+
+    public int getConnectTimeoutMs() {
+      return connectTimeoutMs;
+    }
+
+    public void setConnectTimeoutMs(int connectTimeoutMs) {
+      this.connectTimeoutMs = connectTimeoutMs;
+    }
+
+    public Retry getRetry() {
+      return retry;
+    }
+
+    public void setRetry(Retry retry) {
+      this.retry = retry;
+    }
+
+    public CircuitBreaker getCircuitBreaker() {
+      return circuitBreaker;
+    }
+
+    public void setCircuitBreaker(CircuitBreaker circuitBreaker) {
+      this.circuitBreaker = circuitBreaker;
+    }
+  }
+
+  public static class Retry {
+    private boolean enabled = true;
+    private int attempts = 2;
+    private int backoffMs = 200;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public int getAttempts() {
+      return attempts;
+    }
+
+    public void setAttempts(int attempts) {
+      this.attempts = attempts;
+    }
+
+    public int getBackoffMs() {
+      return backoffMs;
+    }
+
+    public void setBackoffMs(int backoffMs) {
+      this.backoffMs = backoffMs;
+    }
+  }
+
+  public static class CircuitBreaker {
+    private boolean enabled = true;
+    private int failureRateThreshold = 50;
+    private int slowCallRateThreshold = 50;
+    private int waitDurationInOpenStateMs = 10000;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public int getFailureRateThreshold() {
+      return failureRateThreshold;
+    }
+
+    public void setFailureRateThreshold(int failureRateThreshold) {
+      this.failureRateThreshold = failureRateThreshold;
+    }
+
+    public int getSlowCallRateThreshold() {
+      return slowCallRateThreshold;
+    }
+
+    public void setSlowCallRateThreshold(int slowCallRateThreshold) {
+      this.slowCallRateThreshold = slowCallRateThreshold;
+    }
+
+    public int getWaitDurationInOpenStateMs() {
+      return waitDurationInOpenStateMs;
+    }
+
+    public void setWaitDurationInOpenStateMs(int waitDurationInOpenStateMs) {
+      this.waitDurationInOpenStateMs = waitDurationInOpenStateMs;
+    }
+  }
+
+  public static class TrafficControl {
+    private GlobalRateLimit globalRateLimit = new GlobalRateLimit();
+
+    public GlobalRateLimit getGlobalRateLimit() {
+      return globalRateLimit;
+    }
+
+    public void setGlobalRateLimit(GlobalRateLimit globalRateLimit) {
+      this.globalRateLimit = globalRateLimit;
+    }
+  }
+
+  public static class GlobalRateLimit {
+    private boolean enabled = true;
+    private int requestsPerSecond = 300;
+    private int burstCapacity = 600;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public int getRequestsPerSecond() {
+      return requestsPerSecond;
+    }
+
+    public void setRequestsPerSecond(int requestsPerSecond) {
+      this.requestsPerSecond = requestsPerSecond;
+    }
+
+    public int getBurstCapacity() {
+      return burstCapacity;
+    }
+
+    public void setBurstCapacity(int burstCapacity) {
+      this.burstCapacity = burstCapacity;
+    }
+  }
+
+  public static class RouteRule {
+    private String id;
+    private String path;
+    private String target;
+    private int rateLimitRps;
+    private WriteProtection writeProtection = new WriteProtection();
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(String id) {
+      this.id = id;
+    }
+
+    public String getPath() {
+      return path;
+    }
+
+    public void setPath(String path) {
+      this.path = path;
+    }
+
+    public String getTarget() {
+      return target;
+    }
+
+    public void setTarget(String target) {
+      this.target = target;
+    }
+
+    public int getRateLimitRps() {
+      return rateLimitRps;
+    }
+
+    public void setRateLimitRps(int rateLimitRps) {
+      this.rateLimitRps = rateLimitRps;
+    }
+
+    public WriteProtection getWriteProtection() {
+      return writeProtection;
+    }
+
+    public void setWriteProtection(WriteProtection writeProtection) {
+      this.writeProtection = writeProtection;
+    }
+  }
+
+  public static class WriteProtection {
+    private boolean enabledDuringCutover;
+    private List<String> methods = new ArrayList<>();
+
+    public boolean isEnabledDuringCutover() {
+      return enabledDuringCutover;
+    }
+
+    public void setEnabledDuringCutover(boolean enabledDuringCutover) {
+      this.enabledDuringCutover = enabledDuringCutover;
+    }
+
+    public List<String> getMethods() {
+      return methods;
+    }
+
+    public void setMethods(List<String> methods) {
+      this.methods = methods;
+    }
+  }
+
+  public static class CutoverSwitches {
+    private boolean blockLegacyWrites;
+    private boolean allowReadOnlyFallback;
+    private EmergencyStop emergencyStop = new EmergencyStop();
+
+    public boolean isBlockLegacyWrites() {
+      return blockLegacyWrites;
+    }
+
+    public void setBlockLegacyWrites(boolean blockLegacyWrites) {
+      this.blockLegacyWrites = blockLegacyWrites;
+    }
+
+    public boolean isAllowReadOnlyFallback() {
+      return allowReadOnlyFallback;
+    }
+
+    public void setAllowReadOnlyFallback(boolean allowReadOnlyFallback) {
+      this.allowReadOnlyFallback = allowReadOnlyFallback;
+    }
+
+    public EmergencyStop getEmergencyStop() {
+      return emergencyStop;
+    }
+
+    public void setEmergencyStop(EmergencyStop emergencyStop) {
+      this.emergencyStop = emergencyStop;
+    }
+  }
+
+  public static class EmergencyStop {
+    private boolean enabled;
+    private int httpStatus = 503;
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    public int getHttpStatus() {
+      return httpStatus;
+    }
+
+    public void setHttpStatus(int httpStatus) {
+      this.httpStatus = httpStatus;
+    }
+  }
+
+  public void normalize() {
+    if (defaults == null) {
+      defaults = new Defaults();
+    }
+    if (trafficControl == null) {
+      trafficControl = new TrafficControl();
+    }
+    if (routes == null) {
+      routes = new ArrayList<>();
+    }
+    if (cutoverSwitches == null) {
+      cutoverSwitches = new CutoverSwitches();
+    }
+
+    routes.removeIf(route -> route == null || Objects.isNull(route.getId()) || Objects.isNull(route.getPath()) || Objects.isNull(route.getTarget()));
+  }
+}

--- a/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/policy/GatewayPolicyLoader.java
+++ b/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/policy/GatewayPolicyLoader.java
@@ -1,0 +1,63 @@
+package kr.co.computermate.scmrft.gateway.policy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GatewayPolicyLoader {
+  private static final String DEFAULT_REPO_POLICY_PATH = "infra/gateway/policies/cutover-isolation.yaml";
+  private static final String DEFAULT_CLASSPATH_POLICY_PATH = "policy/cutover-isolation.yaml";
+
+  private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+  private final String configuredPolicyPath;
+
+  public GatewayPolicyLoader(@Value("${gateway.policy.path:}") String configuredPolicyPath) {
+    this.configuredPolicyPath = configuredPolicyPath;
+  }
+
+  public GatewayPolicyDocument load() {
+    List<Path> candidates = new ArrayList<>();
+    if (configuredPolicyPath != null && !configuredPolicyPath.isBlank()) {
+      candidates.add(Path.of(configuredPolicyPath));
+    }
+    candidates.add(Path.of(DEFAULT_REPO_POLICY_PATH));
+
+    for (Path candidate : candidates) {
+      if (!candidate.isAbsolute()) {
+        candidate = Path.of("").toAbsolutePath().resolve(candidate).normalize();
+      }
+      if (Files.exists(candidate)) {
+        try (InputStream is = Files.newInputStream(candidate)) {
+          GatewayPolicyDocument document = yamlMapper.readValue(is, GatewayPolicyDocument.class);
+          document.normalize();
+          return document;
+        }
+        catch (IOException e) {
+          throw new IllegalStateException("failed to read gateway policy from file: " + candidate, e);
+        }
+      }
+    }
+
+    ClassPathResource resource = new ClassPathResource(DEFAULT_CLASSPATH_POLICY_PATH);
+    if (!resource.exists()) {
+      throw new IllegalStateException("gateway policy file not found in file system or classpath");
+    }
+    try (InputStream is = resource.getInputStream()) {
+      GatewayPolicyDocument document = yamlMapper.readValue(is, GatewayPolicyDocument.class);
+      document.normalize();
+      return document;
+    }
+    catch (IOException e) {
+      throw new IllegalStateException("failed to read gateway policy from classpath", e);
+    }
+  }
+}

--- a/services/gateway/src/main/resources/application.yml
+++ b/services/gateway/src/main/resources/application.yml
@@ -1,0 +1,27 @@
+spring:
+  application:
+    name: gateway
+  cloud:
+    gateway:
+      httpclient:
+        connect-timeout: 2000
+        response-timeout: 5s
+      default-filters:
+        - PreserveHostHeader
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+
+gateway:
+  policy:
+    path: ${GATEWAY_POLICY_PATH:infra/gateway/policies/cutover-isolation.yaml}
+  cutover:
+    emergency-stop:
+      enabled: ${GATEWAY_EMERGENCY_STOP_ENABLED:false}
+      http-status: ${GATEWAY_EMERGENCY_STOP_STATUS:503}

--- a/services/gateway/src/main/resources/policy/cutover-isolation.yaml
+++ b/services/gateway/src/main/resources/policy/cutover-isolation.yaml
@@ -1,0 +1,49 @@
+policyVersion: 1
+name: cutover-isolation
+
+defaults:
+  requestTimeoutMs: 5000
+  connectTimeoutMs: 2000
+  retry:
+    enabled: true
+    attempts: 2
+    backoffMs: 200
+  circuitBreaker:
+    enabled: true
+    failureRateThreshold: 50
+    slowCallRateThreshold: 50
+    waitDurationInOpenStateMs: 10000
+
+trafficControl:
+  globalRateLimit:
+    enabled: true
+    requestsPerSecond: 300
+    burstCapacity: 600
+
+routes:
+  - id: auth
+    path: /api/auth/**
+    target: http://localhost:8081
+    rateLimitRps: 80
+  - id: member
+    path: /api/member/**
+    target: http://localhost:8082
+    rateLimitRps: 80
+  - id: order-lot
+    path: /api/order-lot/**
+    target: http://localhost:8085
+    rateLimitRps: 60
+    writeProtection:
+      enabledDuringCutover: true
+      methods: [POST, PUT, DELETE, PATCH]
+  - id: file
+    path: /api/file/**
+    target: http://localhost:8087
+    rateLimitRps: 40
+
+cutoverSwitches:
+  blockLegacyWrites: true
+  allowReadOnlyFallback: true
+  emergencyStop:
+    enabled: true
+    httpStatus: 503

--- a/services/gateway/src/test/java/kr/co/computermate/scmrft/gateway/policy/GatewayPolicyLoaderTests.java
+++ b/services/gateway/src/test/java/kr/co/computermate/scmrft/gateway/policy/GatewayPolicyLoaderTests.java
@@ -1,0 +1,17 @@
+package kr.co.computermate.scmrft.gateway.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class GatewayPolicyLoaderTests {
+  @Test
+  void loadsPolicyFromClasspathWhenFilePathMissing() {
+    GatewayPolicyLoader loader = new GatewayPolicyLoader("non-existing-policy.yaml");
+    GatewayPolicyDocument document = loader.load();
+
+    assertThat(document.getName()).isEqualTo("cutover-isolation");
+    assertThat(document.getRoutes()).isNotEmpty();
+    assertThat(document.getCutoverSwitches().getEmergencyStop().getHttpStatus()).isEqualTo(503);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = "scm-rft"
 
 include(":services:auth")
+include(":services:gateway")
 include(":services:member")
 include(":services:board")
 include(":services:quality-doc")


### PR DESCRIPTION
## Summary
- add services/gateway module with Spring Cloud Gateway runtime
- add route + policy loading baseline for big-bang cutover control
- wire gateway into root gradle/settings and dev run scripts

## Validation
- ci-run-gate.ps1 -Gate build
- ci-run-gate.ps1 -Gate unit-integration-test
- ci-run-gate.ps1 -Gate smoke-test

Closes #3