### PR TITLE
[SCM-205] DB 표준화 착수: datasource/flyway baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,14 @@
-# Database
+# Database (container)
 MSSQL_SA_PASSWORD=YourStrong!Passw0rd
+
+# Service datasource/flyway standard
+SCM_DB_URL=jdbc:sqlserver://localhost:1433;databaseName=scm_rft;encrypt=true;trustServerCertificate=true
+SCM_DB_USER=sa
+SCM_DB_PASSWORD=YourStrong!Passw0rd
+SCM_DB_DRIVER=com.microsoft.sqlserver.jdbc.SQLServerDriver
+SCM_FLYWAY_ENABLED=false
+SCM_FLYWAY_LOCATIONS=filesystem:./migration/flyway
+SCM_FLYWAY_TABLE=flyway_schema_history
 
 # RabbitMQ
 RABBITMQ_DEFAULT_USER=scm

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,5 +1,15 @@
 # Staging-like rehearsal environment variables
 MSSQL_SA_PASSWORD=YourStrong!Passw0rd
+
+# Service datasource/flyway standard
+SCM_DB_URL=jdbc:sqlserver://localhost:1433;databaseName=scm_rft_staging;encrypt=true;trustServerCertificate=true
+SCM_DB_USER=sa
+SCM_DB_PASSWORD=YourStrong!Passw0rd
+SCM_DB_DRIVER=com.microsoft.sqlserver.jdbc.SQLServerDriver
+SCM_FLYWAY_ENABLED=true
+SCM_FLYWAY_LOCATIONS=filesystem:./migration/flyway
+SCM_FLYWAY_TABLE=flyway_schema_history
+
 RABBITMQ_DEFAULT_USER=scm_stage
 RABBITMQ_DEFAULT_PASS=scm_stage_1234
 GRAFANA_ADMIN_USER=admin

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,12 @@ configure(serviceProjects) {
   dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
+    implementation "org.springframework.boot:spring-boot-starter-data-jdbc"
+    implementation "org.flywaydb:flyway-core"
+
+    runtimeOnly "com.microsoft.sqlserver:mssql-jdbc"
+    runtimeOnly "com.h2database:h2"
+
     testImplementation "org.springframework.boot:spring-boot-starter-test"
   }
 

--- a/services/auth/src/main/resources/application.yml
+++ b/services/auth/src/main/resources/application.yml
@@ -1,5 +1,20 @@
 spring:
   application:
     name: auth
+  datasource:
+    url: ${SCM_DB_URL:jdbc:h2:mem:auth;MODE=MSSQLServer;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${SCM_DB_USER:sa}
+    password: ${SCM_DB_PASSWORD:}
+    driver-class-name: ${SCM_DB_DRIVER:org.h2.Driver}
+  flyway:
+    enabled: ${SCM_FLYWAY_ENABLED:false}
+    baseline-on-migrate: true
+    locations: ${SCM_FLYWAY_LOCATIONS:filesystem:./migration/flyway}
+    table: ${SCM_FLYWAY_TABLE:flyway_schema_history}
 server:
   port: 8081
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus

--- a/services/board/src/main/resources/application.yml
+++ b/services/board/src/main/resources/application.yml
@@ -1,5 +1,20 @@
 spring:
   application:
     name: board
+  datasource:
+    url: ${SCM_DB_URL:jdbc:h2:mem:board;MODE=MSSQLServer;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${SCM_DB_USER:sa}
+    password: ${SCM_DB_PASSWORD:}
+    driver-class-name: ${SCM_DB_DRIVER:org.h2.Driver}
+  flyway:
+    enabled: ${SCM_FLYWAY_ENABLED:false}
+    baseline-on-migrate: true
+    locations: ${SCM_FLYWAY_LOCATIONS:filesystem:./migration/flyway}
+    table: ${SCM_FLYWAY_TABLE:flyway_schema_history}
 server:
   port: 8083
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus

--- a/services/file/src/main/resources/application.yml
+++ b/services/file/src/main/resources/application.yml
@@ -1,5 +1,20 @@
 spring:
   application:
     name: file
+  datasource:
+    url: ${SCM_DB_URL:jdbc:h2:mem:file;MODE=MSSQLServer;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${SCM_DB_USER:sa}
+    password: ${SCM_DB_PASSWORD:}
+    driver-class-name: ${SCM_DB_DRIVER:org.h2.Driver}
+  flyway:
+    enabled: ${SCM_FLYWAY_ENABLED:false}
+    baseline-on-migrate: true
+    locations: ${SCM_FLYWAY_LOCATIONS:filesystem:./migration/flyway}
+    table: ${SCM_FLYWAY_TABLE:flyway_schema_history}
 server:
   port: 8087
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus

--- a/services/inventory/src/main/resources/application.yml
+++ b/services/inventory/src/main/resources/application.yml
@@ -1,5 +1,20 @@
 spring:
   application:
     name: inventory
+  datasource:
+    url: ${SCM_DB_URL:jdbc:h2:mem:inventory;MODE=MSSQLServer;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${SCM_DB_USER:sa}
+    password: ${SCM_DB_PASSWORD:}
+    driver-class-name: ${SCM_DB_DRIVER:org.h2.Driver}
+  flyway:
+    enabled: ${SCM_FLYWAY_ENABLED:false}
+    baseline-on-migrate: true
+    locations: ${SCM_FLYWAY_LOCATIONS:filesystem:./migration/flyway}
+    table: ${SCM_FLYWAY_TABLE:flyway_schema_history}
 server:
   port: 8086
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus

--- a/services/member/src/main/resources/application.yml
+++ b/services/member/src/main/resources/application.yml
@@ -1,5 +1,20 @@
 spring:
   application:
     name: member
+  datasource:
+    url: ${SCM_DB_URL:jdbc:h2:mem:member;MODE=MSSQLServer;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${SCM_DB_USER:sa}
+    password: ${SCM_DB_PASSWORD:}
+    driver-class-name: ${SCM_DB_DRIVER:org.h2.Driver}
+  flyway:
+    enabled: ${SCM_FLYWAY_ENABLED:false}
+    baseline-on-migrate: true
+    locations: ${SCM_FLYWAY_LOCATIONS:filesystem:./migration/flyway}
+    table: ${SCM_FLYWAY_TABLE:flyway_schema_history}
 server:
   port: 8082
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus

--- a/services/order-lot/src/main/resources/application.yml
+++ b/services/order-lot/src/main/resources/application.yml
@@ -1,5 +1,20 @@
 spring:
   application:
     name: order-lot
+  datasource:
+    url: ${SCM_DB_URL:jdbc:h2:mem:order_lot;MODE=MSSQLServer;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${SCM_DB_USER:sa}
+    password: ${SCM_DB_PASSWORD:}
+    driver-class-name: ${SCM_DB_DRIVER:org.h2.Driver}
+  flyway:
+    enabled: ${SCM_FLYWAY_ENABLED:false}
+    baseline-on-migrate: true
+    locations: ${SCM_FLYWAY_LOCATIONS:filesystem:./migration/flyway}
+    table: ${SCM_FLYWAY_TABLE:flyway_schema_history}
 server:
   port: 8085
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus

--- a/services/quality-doc/src/main/resources/application.yml
+++ b/services/quality-doc/src/main/resources/application.yml
@@ -1,5 +1,20 @@
 spring:
   application:
     name: quality-doc
+  datasource:
+    url: ${SCM_DB_URL:jdbc:h2:mem:quality_doc;MODE=MSSQLServer;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${SCM_DB_USER:sa}
+    password: ${SCM_DB_PASSWORD:}
+    driver-class-name: ${SCM_DB_DRIVER:org.h2.Driver}
+  flyway:
+    enabled: ${SCM_FLYWAY_ENABLED:false}
+    baseline-on-migrate: true
+    locations: ${SCM_FLYWAY_LOCATIONS:filesystem:./migration/flyway}
+    table: ${SCM_FLYWAY_TABLE:flyway_schema_history}
 server:
   port: 8084
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus

--- a/services/report/src/main/resources/application.yml
+++ b/services/report/src/main/resources/application.yml
@@ -1,5 +1,20 @@
 spring:
   application:
     name: report
+  datasource:
+    url: ${SCM_DB_URL:jdbc:h2:mem:report;MODE=MSSQLServer;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
+    username: ${SCM_DB_USER:sa}
+    password: ${SCM_DB_PASSWORD:}
+    driver-class-name: ${SCM_DB_DRIVER:org.h2.Driver}
+  flyway:
+    enabled: ${SCM_FLYWAY_ENABLED:false}
+    baseline-on-migrate: true
+    locations: ${SCM_FLYWAY_LOCATIONS:filesystem:./migration/flyway}
+    table: ${SCM_FLYWAY_TABLE:flyway_schema_history}
 server:
   port: 8088
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus

--- a/shared/persistence/README.md
+++ b/shared/persistence/README.md
@@ -1,0 +1,23 @@
+# Persistence Baseline (SCM-205)
+
+This directory defines the shared DB standard for all SCM_RFT services.
+
+## Standard runtime properties
+- `SCM_DB_URL`
+- `SCM_DB_USER`
+- `SCM_DB_PASSWORD`
+- `SCM_DB_DRIVER`
+- `SCM_FLYWAY_ENABLED`
+- `SCM_FLYWAY_LOCATIONS`
+- `SCM_FLYWAY_TABLE`
+
+## Current baseline decisions
+- Every service includes `spring-boot-starter-data-jdbc`.
+- Flyway is included in every service to keep schema migration behavior consistent.
+- SQL Server driver is the target runtime driver.
+- H2 is included for local/default bootstrap without external DB dependencies.
+- Default Flyway mode is disabled in local profile (`SCM_FLYWAY_ENABLED=false`) to avoid accidental migrations.
+
+## Migration source
+- Canonical SQL scripts are in `migration/flyway`.
+- Use `scripts/ci-run-gate.ps1 -Gate migration-dry-run` before PR merge.


### PR DESCRIPTION
## Summary
- add common DB dependencies (data-jdbc, flyway, sqlserver, h2) for all service modules
- standardize datasource/flyway runtime properties across 8 services
- add env examples for local/staging DB standard properties
- add shared persistence baseline document

## Validation
- ci-run-gate.ps1 -Gate build
- ci-run-gate.ps1 -Gate unit-integration-test
- ci-run-gate.ps1 -Gate smoke-test

Closes #2