### PR TITLE
[SCM-210] Order-Lot P0 API MVP implementation

### DIFF
--- a/migration/flyway/V7__order_lot_query_indexes.sql
+++ b/migration/flyway/V7__order_lot_query_indexes.sql
@@ -1,0 +1,25 @@
+/*
+  SCM_RFT order-lot P0 query index tuning
+  Target DB: SQL Server
+*/
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'ix_orders_status_order_no' AND object_id = OBJECT_ID(N'dbo.orders'))
+BEGIN
+    CREATE INDEX ix_orders_status_order_no
+        ON dbo.orders (status, order_no);
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'ix_orders_member_status_order_no' AND object_id = OBJECT_ID(N'dbo.orders'))
+BEGIN
+    CREATE INDEX ix_orders_member_status_order_no
+        ON dbo.orders (member_id, status, order_no);
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = N'ix_order_lots_order_no_lot_no' AND object_id = OBJECT_ID(N'dbo.order_lots'))
+BEGIN
+    CREATE INDEX ix_order_lots_order_no_lot_no
+        ON dbo.order_lots (order_no, lot_no);
+END;
+GO

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/ApiErrorResponse.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/ApiErrorResponse.java
@@ -1,0 +1,16 @@
+package kr.co.computermate.scmrft.orderlot.api;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ApiErrorResponse(
+    String code,
+    String message,
+    String traceId,
+    String path,
+    Instant timestamp,
+    List<FieldErrorItem> details
+) {
+  public record FieldErrorItem(String field, String reason) {
+  }
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/LotDetailResponse.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/LotDetailResponse.java
@@ -1,0 +1,11 @@
+package kr.co.computermate.scmrft.orderlot.api;
+
+import java.math.BigDecimal;
+
+public record LotDetailResponse(
+    String lotId,
+    String orderId,
+    BigDecimal quantity,
+    String status
+) {
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderDetailResponse.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderDetailResponse.java
@@ -1,0 +1,13 @@
+package kr.co.computermate.scmrft.orderlot.api;
+
+import java.time.Instant;
+
+public record OrderDetailResponse(
+    String orderId,
+    String supplierId,
+    String status,
+    Instant orderedAt,
+    Instant expectedDeliveryAt,
+    Integer totalLotCount
+) {
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderLotController.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderLotController.java
@@ -1,0 +1,57 @@
+package kr.co.computermate.scmrft.orderlot.api;
+
+import jakarta.validation.Valid;
+import kr.co.computermate.scmrft.orderlot.service.OrderLotCommandService;
+import kr.co.computermate.scmrft.orderlot.service.OrderLotQueryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/order-lot/v1")
+public class OrderLotController {
+  private final OrderLotQueryService queryService;
+  private final OrderLotCommandService commandService;
+
+  public OrderLotController(
+      OrderLotQueryService queryService,
+      OrderLotCommandService commandService
+  ) {
+    this.queryService = queryService;
+    this.commandService = commandService;
+  }
+
+  @GetMapping("/orders")
+  public SearchOrdersResponse searchOrders(
+      @RequestParam(value = "supplierId", required = false) String supplierId,
+      @RequestParam(value = "status", required = false) String status,
+      @RequestParam(value = "keyword", required = false) String keyword,
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "20") int size
+  ) {
+    return queryService.searchOrders(supplierId, status, keyword, page, size);
+  }
+
+  @GetMapping("/orders/{orderId}")
+  public OrderDetailResponse getOrderById(@PathVariable("orderId") String orderId) {
+    return queryService.getOrderById(orderId);
+  }
+
+  @GetMapping("/lots/{lotId}")
+  public LotDetailResponse getLotById(@PathVariable("lotId") String lotId) {
+    return queryService.getLotById(lotId);
+  }
+
+  @PostMapping("/orders/{orderId}/status")
+  public ResponseEntity<OrderStatusChangeResponse> changeOrderStatus(
+      @PathVariable("orderId") String orderId,
+      @Valid @RequestBody OrderStatusChangeRequest request
+  ) {
+    return ResponseEntity.ok(commandService.changeOrderStatus(orderId, request));
+  }
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderLotExceptionHandler.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderLotExceptionHandler.java
@@ -1,0 +1,101 @@
+package kr.co.computermate.scmrft.orderlot.api;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import kr.co.computermate.scmrft.orderlot.service.OrderLotApiException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice(assignableTypes = OrderLotController.class)
+public class OrderLotExceptionHandler {
+  @ExceptionHandler(OrderLotApiException.class)
+  public ResponseEntity<ApiErrorResponse> handleOrderLotApiException(
+      OrderLotApiException ex,
+      HttpServletRequest request
+  ) {
+    return withTraceId(request, ex.getStatus(), ex.getCode(), ex.getMessage(), List.of());
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiErrorResponse> handleValidationError(
+      MethodArgumentNotValidException ex,
+      HttpServletRequest request
+  ) {
+    List<ApiErrorResponse.FieldErrorItem> details = ex.getBindingResult().getFieldErrors().stream()
+        .map(error -> new ApiErrorResponse.FieldErrorItem(error.getField(), error.getDefaultMessage()))
+        .toList();
+    return withTraceId(request, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Validation failed.", details);
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ApiErrorResponse> handleTypeMismatch(HttpServletRequest request) {
+    return withTraceId(
+        request,
+        HttpStatus.BAD_REQUEST,
+        "VALIDATION_ERROR",
+        "Invalid query parameter type.",
+        List.of()
+    );
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ApiErrorResponse> handleMalformedPayload(HttpServletRequest request) {
+    return withTraceId(
+        request,
+        HttpStatus.BAD_REQUEST,
+        "VALIDATION_ERROR",
+        "Malformed request payload.",
+        List.of()
+    );
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiErrorResponse> handleUnexpected(HttpServletRequest request) {
+    return withTraceId(
+        request,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "INTERNAL_ERROR",
+        "Unexpected error occurred.",
+        List.of()
+    );
+  }
+
+  private ResponseEntity<ApiErrorResponse> withTraceId(
+      HttpServletRequest request,
+      HttpStatus status,
+      String code,
+      String message,
+      List<ApiErrorResponse.FieldErrorItem> details
+  ) {
+    String traceId = resolveTraceId(request);
+    ApiErrorResponse body = new ApiErrorResponse(
+        code,
+        message,
+        traceId,
+        request.getRequestURI(),
+        Instant.now(),
+        details
+    );
+
+    return ResponseEntity.status(status)
+        .header("X-Trace-Id", traceId)
+        .header(HttpHeaders.CONTENT_TYPE, "application/json")
+        .body(body);
+  }
+
+  private String resolveTraceId(HttpServletRequest request) {
+    String traceId = request.getHeader("X-Trace-Id");
+    if (traceId == null || traceId.isBlank()) {
+      return UUID.randomUUID().toString();
+    }
+    return traceId;
+  }
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderStatusChangeRequest.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderStatusChangeRequest.java
@@ -1,0 +1,15 @@
+package kr.co.computermate.scmrft.orderlot.api;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record OrderStatusChangeRequest(
+    @NotBlank(message = "targetStatus is required.")
+    String targetStatus,
+    @NotBlank(message = "changedBy is required.")
+    @Size(max = 40, message = "changedBy must be less than or equal to 40 characters.")
+    String changedBy,
+    @Size(max = 200, message = "reason must be less than or equal to 200 characters.")
+    String reason
+) {
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderStatusChangeResponse.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderStatusChangeResponse.java
@@ -1,0 +1,11 @@
+package kr.co.computermate.scmrft.orderlot.api;
+
+import java.time.Instant;
+
+public record OrderStatusChangeResponse(
+    String orderId,
+    String beforeStatus,
+    String afterStatus,
+    Instant changedAt
+) {
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderSummaryResponse.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/OrderSummaryResponse.java
@@ -1,0 +1,11 @@
+package kr.co.computermate.scmrft.orderlot.api;
+
+import java.time.Instant;
+
+public record OrderSummaryResponse(
+    String orderId,
+    String supplierId,
+    String status,
+    Instant orderedAt
+) {
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/PageMetaResponse.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/PageMetaResponse.java
@@ -1,0 +1,10 @@
+package kr.co.computermate.scmrft.orderlot.api;
+
+public record PageMetaResponse(
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean hasNext
+) {
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/SearchOrdersResponse.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/api/SearchOrdersResponse.java
@@ -1,0 +1,9 @@
+package kr.co.computermate.scmrft.orderlot.api;
+
+import java.util.List;
+
+public record SearchOrdersResponse(
+    List<OrderSummaryResponse> items,
+    PageMetaResponse page
+) {
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/repository/LotEntity.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/repository/LotEntity.java
@@ -1,0 +1,11 @@
+package kr.co.computermate.scmrft.orderlot.repository;
+
+import java.math.BigDecimal;
+
+public record LotEntity(
+    String lotId,
+    String orderId,
+    BigDecimal quantity,
+    String status
+) {
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/repository/LotRepository.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/repository/LotRepository.java
@@ -1,0 +1,44 @@
+package kr.co.computermate.scmrft.orderlot.repository;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class LotRepository {
+  private final JdbcClient jdbcClient;
+
+  public LotRepository(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  public Optional<LotEntity> findById(String lotId) {
+    List<LotEntity> rows = jdbcClient.sql("""
+            SELECT lot_no, order_no, quantity, status
+            FROM dbo.order_lots
+            WHERE lot_no = :lotId
+        """)
+        .param("lotId", lotId)
+        .query((rs, rowNum) -> new LotEntity(
+            rs.getString("lot_no"),
+            rs.getString("order_no"),
+            rs.getBigDecimal("quantity"),
+            rs.getString("status")
+        ))
+        .list();
+    return rows.stream().findFirst();
+  }
+
+  public int countByOrderId(String orderId) {
+    Integer count = jdbcClient.sql("""
+            SELECT COUNT(*) AS lot_count
+            FROM dbo.order_lots
+            WHERE order_no = :orderId
+        """)
+        .param("orderId", orderId)
+        .query(Integer.class)
+        .single();
+    return count == null ? 0 : count;
+  }
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/repository/OrderEntity.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/repository/OrderEntity.java
@@ -1,0 +1,11 @@
+package kr.co.computermate.scmrft.orderlot.repository;
+
+import java.time.Instant;
+
+public record OrderEntity(
+    String orderId,
+    String supplierId,
+    String status,
+    Instant orderedAt
+) {
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/repository/OrderRepository.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/repository/OrderRepository.java
@@ -1,0 +1,105 @@
+package kr.co.computermate.scmrft.orderlot.repository;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class OrderRepository {
+  private final JdbcClient jdbcClient;
+
+  public OrderRepository(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  public Optional<OrderEntity> findById(String orderId) {
+    List<OrderEntity> rows = jdbcClient.sql("""
+            SELECT order_no, member_id, status, order_date, created_at
+            FROM dbo.orders
+            WHERE order_no = :orderId
+        """)
+        .param("orderId", orderId)
+        .query((rs, rowNum) -> new OrderEntity(
+            rs.getString("order_no"),
+            rs.getString("member_id"),
+            rs.getString("status"),
+            toOrderedAt(rs.getTimestamp("created_at"), rs.getDate("order_date"))
+        ))
+        .list();
+
+    return rows.stream().findFirst();
+  }
+
+  public OrderSearchResult search(
+      String supplierId,
+      String status,
+      String keywordPrefix,
+      int offset,
+      int size
+  ) {
+    Long total = jdbcClient.sql("""
+            SELECT COUNT(*) AS total
+            FROM dbo.orders
+            WHERE (:supplierId IS NULL OR member_id = :supplierId)
+              AND (:status IS NULL OR status = :status)
+              AND (:keywordPrefix IS NULL OR order_no LIKE :keywordPrefix)
+        """)
+        .param("supplierId", supplierId)
+        .param("status", status)
+        .param("keywordPrefix", keywordPrefix)
+        .query(Long.class)
+        .single();
+
+    List<OrderEntity> items = jdbcClient.sql("""
+            SELECT order_no, member_id, status, order_date, created_at
+            FROM dbo.orders
+            WHERE (:supplierId IS NULL OR member_id = :supplierId)
+              AND (:status IS NULL OR status = :status)
+              AND (:keywordPrefix IS NULL OR order_no LIKE :keywordPrefix)
+            ORDER BY created_at DESC, order_no DESC
+            OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY
+        """)
+        .param("supplierId", supplierId)
+        .param("status", status)
+        .param("keywordPrefix", keywordPrefix)
+        .param("offset", offset)
+        .param("size", size)
+        .query((rs, rowNum) -> new OrderEntity(
+            rs.getString("order_no"),
+            rs.getString("member_id"),
+            rs.getString("status"),
+            toOrderedAt(rs.getTimestamp("created_at"), rs.getDate("order_date"))
+        ))
+        .list();
+
+    return new OrderSearchResult(items, total == null ? 0L : total);
+  }
+
+  public int updateStatus(String orderId, String beforeStatus, String afterStatus) {
+    return jdbcClient.sql("""
+            UPDATE dbo.orders
+            SET status = :afterStatus
+            WHERE order_no = :orderId
+              AND status = :beforeStatus
+        """)
+        .param("orderId", orderId)
+        .param("beforeStatus", beforeStatus)
+        .param("afterStatus", afterStatus)
+        .update();
+  }
+
+  private Instant toOrderedAt(Timestamp createdAt, Date orderDate) {
+    if (createdAt != null) {
+      return createdAt.toInstant();
+    }
+    if (orderDate != null) {
+      return orderDate.toLocalDate().atStartOfDay().toInstant(ZoneOffset.UTC);
+    }
+    return null;
+  }
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/repository/OrderSearchResult.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/repository/OrderSearchResult.java
@@ -1,0 +1,9 @@
+package kr.co.computermate.scmrft.orderlot.repository;
+
+import java.util.List;
+
+public record OrderSearchResult(
+    List<OrderEntity> items,
+    long total
+) {
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/service/OrderLotApiException.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/service/OrderLotApiException.java
@@ -1,0 +1,42 @@
+package kr.co.computermate.scmrft.orderlot.service;
+
+import org.springframework.http.HttpStatus;
+
+public class OrderLotApiException extends RuntimeException {
+  private final HttpStatus status;
+  private final String code;
+
+  public OrderLotApiException(HttpStatus status, String code, String message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+
+  public HttpStatus getStatus() {
+    return status;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public static OrderLotApiException badRequest(String message) {
+    return new OrderLotApiException(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message);
+  }
+
+  public static OrderLotApiException notFound(String message) {
+    return new OrderLotApiException(HttpStatus.NOT_FOUND, "NOT_FOUND", message);
+  }
+
+  public static OrderLotApiException conflict(String message) {
+    return new OrderLotApiException(HttpStatus.CONFLICT, "CONFLICT", message);
+  }
+
+  public static OrderLotApiException upstreamTimeout(String message) {
+    return new OrderLotApiException(HttpStatus.GATEWAY_TIMEOUT, "UPSTREAM_TIMEOUT", message);
+  }
+
+  public static OrderLotApiException internalError(String message) {
+    return new OrderLotApiException(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", message);
+  }
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/service/OrderLotCommandService.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/service/OrderLotCommandService.java
@@ -1,0 +1,52 @@
+package kr.co.computermate.scmrft.orderlot.service;
+
+import java.time.Instant;
+import kr.co.computermate.scmrft.orderlot.api.OrderStatusChangeRequest;
+import kr.co.computermate.scmrft.orderlot.api.OrderStatusChangeResponse;
+import kr.co.computermate.scmrft.orderlot.repository.OrderEntity;
+import kr.co.computermate.scmrft.orderlot.repository.OrderRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderLotCommandService {
+  private final OrderRepository orderRepository;
+  private final OrderStatusTransitionPolicy transitionPolicy;
+
+  public OrderLotCommandService(
+      OrderRepository orderRepository,
+      OrderStatusTransitionPolicy transitionPolicy
+  ) {
+    this.orderRepository = orderRepository;
+    this.transitionPolicy = transitionPolicy;
+  }
+
+  @Transactional(timeout = 3, isolation = Isolation.READ_COMMITTED)
+  public OrderStatusChangeResponse changeOrderStatus(String orderId, OrderStatusChangeRequest request) {
+    String normalizedOrderId = requireValue(orderId, "orderId is required.");
+    String targetStatus = OrderStatus.normalize(request.targetStatus());
+    String changedBy = requireValue(request.changedBy(), "changedBy is required.");
+
+    OrderEntity order = orderRepository.findById(normalizedOrderId)
+        .orElseThrow(() -> OrderLotApiException.notFound("Order not found."));
+
+    String currentStatus = OrderStatus.normalize(order.status());
+    transitionPolicy.assertAllowed(currentStatus, targetStatus);
+
+    int updated = orderRepository.updateStatus(order.orderId(), currentStatus, targetStatus);
+    if (updated == 0) {
+      throw OrderLotApiException.conflict("Order status changed by another transaction.");
+    }
+
+    Instant changedAt = Instant.now();
+    return new OrderStatusChangeResponse(order.orderId(), currentStatus, targetStatus, changedAt);
+  }
+
+  private String requireValue(String value, String message) {
+    if (value == null || value.trim().isEmpty()) {
+      throw OrderLotApiException.badRequest(message);
+    }
+    return value.trim();
+  }
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/service/OrderLotQueryService.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/service/OrderLotQueryService.java
@@ -1,0 +1,137 @@
+package kr.co.computermate.scmrft.orderlot.service;
+
+import java.util.List;
+import kr.co.computermate.scmrft.orderlot.api.LotDetailResponse;
+import kr.co.computermate.scmrft.orderlot.api.OrderDetailResponse;
+import kr.co.computermate.scmrft.orderlot.api.OrderSummaryResponse;
+import kr.co.computermate.scmrft.orderlot.api.PageMetaResponse;
+import kr.co.computermate.scmrft.orderlot.api.SearchOrdersResponse;
+import kr.co.computermate.scmrft.orderlot.repository.LotEntity;
+import kr.co.computermate.scmrft.orderlot.repository.LotRepository;
+import kr.co.computermate.scmrft.orderlot.repository.OrderEntity;
+import kr.co.computermate.scmrft.orderlot.repository.OrderRepository;
+import kr.co.computermate.scmrft.orderlot.repository.OrderSearchResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OrderLotQueryService {
+  private static final int MAX_PAGE_SIZE = 200;
+
+  private final OrderRepository orderRepository;
+  private final LotRepository lotRepository;
+
+  public OrderLotQueryService(OrderRepository orderRepository, LotRepository lotRepository) {
+    this.orderRepository = orderRepository;
+    this.lotRepository = lotRepository;
+  }
+
+  @Transactional(readOnly = true, timeout = 2)
+  public SearchOrdersResponse searchOrders(
+      String supplierId,
+      String status,
+      String keyword,
+      int page,
+      int size
+  ) {
+    validatePaging(page, size);
+    String normalizedStatus = OrderStatus.normalize(status);
+    String normalizedSupplierId = normalizeToNull(supplierId);
+    String normalizedKeywordPrefix = normalizeKeywordPrefix(keyword);
+
+    OrderSearchResult result = orderRepository.search(
+        normalizedSupplierId,
+        normalizedStatus,
+        normalizedKeywordPrefix,
+        page * size,
+        size
+    );
+
+    List<OrderSummaryResponse> items = result.items().stream()
+        .map(this::toOrderSummary)
+        .toList();
+
+    int totalPages = (int) Math.ceil(result.total() / (double) size);
+    PageMetaResponse pageMeta = new PageMetaResponse(
+        page,
+        size,
+        result.total(),
+        totalPages,
+        page + 1 < totalPages
+    );
+
+    return new SearchOrdersResponse(items, pageMeta);
+  }
+
+  @Transactional(readOnly = true, timeout = 2)
+  public OrderDetailResponse getOrderById(String orderId) {
+    String normalizedOrderId = requireValue(orderId, "orderId is required.");
+    OrderEntity order = orderRepository.findById(normalizedOrderId)
+        .orElseThrow(() -> OrderLotApiException.notFound("Order not found."));
+
+    return new OrderDetailResponse(
+        order.orderId(),
+        order.supplierId(),
+        order.status(),
+        order.orderedAt(),
+        null,
+        lotRepository.countByOrderId(order.orderId())
+    );
+  }
+
+  @Transactional(readOnly = true, timeout = 2)
+  public LotDetailResponse getLotById(String lotId) {
+    String normalizedLotId = requireValue(lotId, "lotId is required.");
+    LotEntity lot = lotRepository.findById(normalizedLotId)
+        .orElseThrow(() -> OrderLotApiException.notFound("Lot not found."));
+
+    return new LotDetailResponse(
+        lot.lotId(),
+        lot.orderId(),
+        lot.quantity(),
+        lot.status()
+    );
+  }
+
+  private OrderSummaryResponse toOrderSummary(OrderEntity entity) {
+    return new OrderSummaryResponse(
+        entity.orderId(),
+        entity.supplierId(),
+        entity.status(),
+        entity.orderedAt()
+    );
+  }
+
+  private void validatePaging(int page, int size) {
+    if (page < 0) {
+      throw OrderLotApiException.badRequest("page must be greater than or equal to 0.");
+    }
+    if (size < 1 || size > MAX_PAGE_SIZE) {
+      throw OrderLotApiException.badRequest("size must be between 1 and 200.");
+    }
+  }
+
+  private String normalizeKeywordPrefix(String keyword) {
+    String normalized = normalizeToNull(keyword);
+    if (normalized == null) {
+      return null;
+    }
+    return normalized + "%";
+  }
+
+  private String requireValue(String value, String message) {
+    String normalized = normalizeToNull(value);
+    if (normalized == null) {
+      throw OrderLotApiException.badRequest(message);
+    }
+    return normalized;
+  }
+
+  private String normalizeToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/service/OrderStatus.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/service/OrderStatus.java
@@ -1,0 +1,31 @@
+package kr.co.computermate.scmrft.orderlot.service;
+
+import java.util.Locale;
+import java.util.Set;
+
+public enum OrderStatus {
+  PENDING,
+  CONFIRMED,
+  IN_PROGRESS,
+  COMPLETED,
+  CANCELED;
+
+  private static final Set<String> VALUES = Set.of(
+      PENDING.name(),
+      CONFIRMED.name(),
+      IN_PROGRESS.name(),
+      COMPLETED.name(),
+      CANCELED.name()
+  );
+
+  public static String normalize(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    String upper = value.trim().toUpperCase(Locale.ROOT);
+    if (!VALUES.contains(upper)) {
+      throw OrderLotApiException.badRequest("status must be one of PENDING, CONFIRMED, IN_PROGRESS, COMPLETED, CANCELED.");
+    }
+    return upper;
+  }
+}

--- a/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/service/OrderStatusTransitionPolicy.java
+++ b/services/order-lot/src/main/java/kr/co/computermate/scmrft/orderlot/service/OrderStatusTransitionPolicy.java
@@ -1,0 +1,31 @@
+package kr.co.computermate.scmrft.orderlot.service;
+
+import java.util.Map;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderStatusTransitionPolicy {
+  private static final Map<String, Set<String>> ALLOWED_TRANSITIONS = Map.of(
+      "PENDING", Set.of("CONFIRMED", "CANCELED"),
+      "CONFIRMED", Set.of("IN_PROGRESS", "CANCELED"),
+      "IN_PROGRESS", Set.of("COMPLETED", "CANCELED"),
+      "COMPLETED", Set.of(),
+      "CANCELED", Set.of()
+  );
+
+  public void assertAllowed(String currentStatus, String targetStatus) {
+    if (currentStatus == null || targetStatus == null) {
+      throw OrderLotApiException.badRequest("currentStatus and targetStatus are required.");
+    }
+
+    if (currentStatus.equals(targetStatus)) {
+      throw OrderLotApiException.conflict("targetStatus is same as current status.");
+    }
+
+    Set<String> allowed = ALLOWED_TRANSITIONS.get(currentStatus);
+    if (allowed == null || !allowed.contains(targetStatus)) {
+      throw OrderLotApiException.conflict("status transition is not allowed.");
+    }
+  }
+}

--- a/services/order-lot/src/test/java/kr/co/computermate/scmrft/orderlot/repository/LotRepositoryIntegrationTests.java
+++ b/services/order-lot/src/test/java/kr/co/computermate/scmrft/orderlot/repository/LotRepositoryIntegrationTests.java
@@ -1,0 +1,50 @@
+package kr.co.computermate.scmrft.orderlot.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+@SpringBootTest
+class LotRepositoryIntegrationTests {
+  @Autowired
+  private JdbcClient jdbcClient;
+
+  @Autowired
+  private LotRepository lotRepository;
+
+  @BeforeEach
+  void setUpSchema() {
+    jdbcClient.sql("CREATE SCHEMA IF NOT EXISTS dbo").update();
+    jdbcClient.sql("""
+            CREATE TABLE IF NOT EXISTS dbo.order_lots (
+                lot_no VARCHAR(50) NOT NULL PRIMARY KEY,
+                order_no VARCHAR(50) NOT NULL,
+                quantity DECIMAL(18,3) NOT NULL,
+                status VARCHAR(20) NOT NULL,
+                created_at TIMESTAMP NOT NULL
+            )
+        """).update();
+    jdbcClient.sql("DELETE FROM dbo.order_lots").update();
+  }
+
+  @Test
+  void findByIdAndCountByOrderIdWorks() {
+    jdbcClient.sql("""
+            INSERT INTO dbo.order_lots(lot_no, order_no, quantity, status, created_at)
+            VALUES ('LOT-1', 'ORD-1', 10.500, 'ALLOCATED', CURRENT_TIMESTAMP),
+                   ('LOT-2', 'ORD-1', 20.500, 'ALLOCATED', CURRENT_TIMESTAMP)
+        """).update();
+
+    LotEntity lot = lotRepository.findById("LOT-1").orElseThrow();
+    int count = lotRepository.countByOrderId("ORD-1");
+
+    assertThat(lot.orderId()).isEqualTo("ORD-1");
+    assertThat(lot.quantity()).isEqualByComparingTo(new BigDecimal("10.500"));
+    assertThat(count).isEqualTo(2);
+  }
+}

--- a/services/order-lot/src/test/java/kr/co/computermate/scmrft/orderlot/repository/OrderRepositoryIntegrationTests.java
+++ b/services/order-lot/src/test/java/kr/co/computermate/scmrft/orderlot/repository/OrderRepositoryIntegrationTests.java
@@ -1,0 +1,70 @@
+package kr.co.computermate.scmrft.orderlot.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+@SpringBootTest
+class OrderRepositoryIntegrationTests {
+  @Autowired
+  private JdbcClient jdbcClient;
+
+  @Autowired
+  private OrderRepository orderRepository;
+
+  @BeforeEach
+  void setUpSchema() {
+    jdbcClient.sql("CREATE SCHEMA IF NOT EXISTS dbo").update();
+    jdbcClient.sql("""
+            CREATE TABLE IF NOT EXISTS dbo.orders (
+                order_no VARCHAR(50) NOT NULL PRIMARY KEY,
+                member_id VARCHAR(50) NOT NULL,
+                order_date DATE NOT NULL,
+                status VARCHAR(20) NOT NULL,
+                created_at TIMESTAMP NOT NULL
+            )
+        """).update();
+    jdbcClient.sql("DELETE FROM dbo.orders").update();
+  }
+
+  @Test
+  void searchFiltersByStatusAndKeyword() {
+    jdbcClient.sql("""
+            INSERT INTO dbo.orders(order_no, member_id, order_date, status, created_at)
+            VALUES ('ORD-001', 'SUP-1', ?, 'PENDING', CURRENT_TIMESTAMP),
+                   ('ORD-ABC', 'SUP-1', ?, 'CONFIRMED', CURRENT_TIMESTAMP),
+                   ('X-001', 'SUP-2', ?, 'PENDING', CURRENT_TIMESTAMP)
+        """)
+        .param(LocalDate.now())
+        .param(LocalDate.now())
+        .param(LocalDate.now())
+        .update();
+
+    OrderSearchResult result = orderRepository.search("SUP-1", "PENDING", "ORD-%", 0, 20);
+
+    assertThat(result.total()).isEqualTo(1L);
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().get(0).orderId()).isEqualTo("ORD-001");
+  }
+
+  @Test
+  void updateStatusUsesCurrentStatusGuard() {
+    jdbcClient.sql("""
+            INSERT INTO dbo.orders(order_no, member_id, order_date, status, created_at)
+            VALUES ('ORD-001', 'SUP-1', ?, 'PENDING', CURRENT_TIMESTAMP)
+        """)
+        .param(LocalDate.now())
+        .update();
+
+    int changed = orderRepository.updateStatus("ORD-001", "PENDING", "CONFIRMED");
+    int notChanged = orderRepository.updateStatus("ORD-001", "PENDING", "IN_PROGRESS");
+
+    assertThat(changed).isEqualTo(1);
+    assertThat(notChanged).isEqualTo(0);
+  }
+}

--- a/services/order-lot/src/test/java/kr/co/computermate/scmrft/orderlot/service/OrderLotCommandServiceTests.java
+++ b/services/order-lot/src/test/java/kr/co/computermate/scmrft/orderlot/service/OrderLotCommandServiceTests.java
@@ -1,0 +1,60 @@
+package kr.co.computermate.scmrft.orderlot.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import kr.co.computermate.scmrft.orderlot.api.OrderStatusChangeRequest;
+import kr.co.computermate.scmrft.orderlot.api.OrderStatusChangeResponse;
+import kr.co.computermate.scmrft.orderlot.repository.OrderEntity;
+import kr.co.computermate.scmrft.orderlot.repository.OrderRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderLotCommandServiceTests {
+  @Mock
+  private OrderRepository orderRepository;
+
+  @Test
+  void changesOrderStatusWhenTransitionIsValid() {
+    OrderStatusTransitionPolicy policy = new OrderStatusTransitionPolicy();
+    OrderLotCommandService service = new OrderLotCommandService(orderRepository, policy);
+    OrderEntity entity = new OrderEntity("ORD-001", "SUP-1", "PENDING", Instant.now());
+
+    when(orderRepository.findById("ORD-001")).thenReturn(Optional.of(entity));
+    when(orderRepository.updateStatus("ORD-001", "PENDING", "CONFIRMED")).thenReturn(1);
+
+    OrderStatusChangeResponse response = service.changeOrderStatus(
+        "ORD-001",
+        new OrderStatusChangeRequest("CONFIRMED", "tester", "approve")
+    );
+
+    assertThat(response.orderId()).isEqualTo("ORD-001");
+    assertThat(response.beforeStatus()).isEqualTo("PENDING");
+    assertThat(response.afterStatus()).isEqualTo("CONFIRMED");
+    verify(orderRepository).updateStatus("ORD-001", "PENDING", "CONFIRMED");
+  }
+
+  @Test
+  void throwsConflictWhenConcurrentUpdateDetected() {
+    OrderStatusTransitionPolicy policy = new OrderStatusTransitionPolicy();
+    OrderLotCommandService service = new OrderLotCommandService(orderRepository, policy);
+    OrderEntity entity = new OrderEntity("ORD-001", "SUP-1", "PENDING", Instant.now());
+
+    when(orderRepository.findById("ORD-001")).thenReturn(Optional.of(entity));
+    when(orderRepository.updateStatus("ORD-001", "PENDING", "CONFIRMED")).thenReturn(0);
+
+    assertThatThrownBy(() -> service.changeOrderStatus(
+        "ORD-001",
+        new OrderStatusChangeRequest("CONFIRMED", "tester", null)
+    ))
+        .isInstanceOf(OrderLotApiException.class)
+        .hasMessageContaining("another transaction");
+  }
+}

--- a/services/order-lot/src/test/java/kr/co/computermate/scmrft/orderlot/service/OrderStatusTransitionPolicyTests.java
+++ b/services/order-lot/src/test/java/kr/co/computermate/scmrft/orderlot/service/OrderStatusTransitionPolicyTests.java
@@ -1,0 +1,23 @@
+package kr.co.computermate.scmrft.orderlot.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class OrderStatusTransitionPolicyTests {
+  private final OrderStatusTransitionPolicy policy = new OrderStatusTransitionPolicy();
+
+  @Test
+  void allowsValidTransition() {
+    assertThatCode(() -> policy.assertAllowed("PENDING", "CONFIRMED"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void rejectsInvalidTransition() {
+    assertThatThrownBy(() -> policy.assertAllowed("COMPLETED", "IN_PROGRESS"))
+        .isInstanceOf(OrderLotApiException.class)
+        .hasMessageContaining("not allowed");
+  }
+}


### PR DESCRIPTION
## Summary
- Implemented Order-Lot P0 MVP APIs (list/detail/lot/status-change)
- Added status transition policy and transactional update guard
- Added repository/service/controller/exception mappings and tests
- Added order-lot query indexes migration (V7)

## Gates
- build: PASS
- unit-integration-test: PASS
- contract-test: PASS
- smoke-test: PASS (gateway e2e smoke skipped by default env)
- migration-dry-run: PASS

## Evidence
- runbooks/evidence/SCM-210-20260226-124328/gate-build.log
- runbooks/evidence/SCM-210-20260226-124328/gate-unit-integration.log
- runbooks/evidence/SCM-210-20260226-124328/gate-contract.log
- runbooks/evidence/SCM-210-20260226-124328/gate-smoke.log
- runbooks/evidence/SCM-210-20260226-124328/gate-migration-dry-run.log