### PR TITLE
[SCM-211] Board + Quality-Doc MVP implementation

### DIFF
--- a/migration/flyway/V6__quality_doc_ack_type.sql
+++ b/migration/flyway/V6__quality_doc_ack_type.sql
@@ -1,0 +1,46 @@
+/*
+  SCM_RFT quality-doc ack idempotency support
+  Target DB: SQL Server
+*/
+
+IF OBJECT_ID(N'dbo.quality_document_acks', N'U') IS NOT NULL
+BEGIN
+    IF COL_LENGTH(N'dbo.quality_document_acks', N'ack_type') IS NULL
+    BEGIN
+        ALTER TABLE dbo.quality_document_acks
+        ADD ack_type NVARCHAR(20) NULL;
+    END;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.quality_document_acks', N'U') IS NOT NULL
+BEGIN
+    UPDATE dbo.quality_document_acks
+    SET ack_type = N'READ'
+    WHERE ack_type IS NULL;
+END;
+GO
+
+IF OBJECT_ID(N'dbo.quality_document_acks', N'U') IS NOT NULL
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM sys.columns
+        WHERE object_id = OBJECT_ID(N'dbo.quality_document_acks')
+          AND name = N'ack_type'
+          AND is_nullable = 1
+    )
+    BEGIN
+        ALTER TABLE dbo.quality_document_acks
+        ALTER COLUMN ack_type NVARCHAR(20) NOT NULL;
+    END;
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = N'ck_quality_document_acks_ack_type')
+BEGIN
+    ALTER TABLE dbo.quality_document_acks
+    ADD CONSTRAINT ck_quality_document_acks_ack_type
+    CHECK (ack_type IN (N'READ', N'CONFIRMED'));
+END;
+GO

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/ApiErrorResponse.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/ApiErrorResponse.java
@@ -1,0 +1,16 @@
+package kr.co.computermate.scmrft.board.api;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ApiErrorResponse(
+    String code,
+    String message,
+    String traceId,
+    String path,
+    Instant timestamp,
+    List<FieldErrorItem> details
+) {
+  public record FieldErrorItem(String field, String reason) {
+  }
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/AttachmentRefRequest.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/AttachmentRefRequest.java
@@ -1,0 +1,9 @@
+package kr.co.computermate.scmrft.board.api;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AttachmentRefRequest(
+    @NotBlank(message = "fileId is required.")
+    String fileId
+) {
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/AttachmentRefResponse.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/AttachmentRefResponse.java
@@ -1,0 +1,7 @@
+package kr.co.computermate.scmrft.board.api;
+
+public record AttachmentRefResponse(
+    String fileId,
+    String fileName
+) {
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/BoardController.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/BoardController.java
@@ -1,0 +1,42 @@
+package kr.co.computermate.scmrft.board.api;
+
+import jakarta.validation.Valid;
+import kr.co.computermate.scmrft.board.service.BoardService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/board/v1")
+public class BoardController {
+  private final BoardService boardService;
+
+  public BoardController(BoardService boardService) {
+    this.boardService = boardService;
+  }
+
+  @GetMapping("/posts")
+  public SearchBoardPostsResponse searchPosts(
+      @RequestParam(value = "boardType", required = false) String boardType,
+      @RequestParam(value = "keyword", required = false) String keyword,
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "20") int size
+  ) {
+    return boardService.searchPosts(boardType, keyword, page, size);
+  }
+
+  @GetMapping("/posts/{postId}")
+  public BoardPostDetailResponse getPostById(@PathVariable("postId") String postId) {
+    return boardService.getPostById(postId);
+  }
+
+  @PostMapping("/posts")
+  public ResponseEntity<CreateBoardPostResponse> createPost(@Valid @RequestBody CreateBoardPostRequest request) {
+    return ResponseEntity.status(201).body(boardService.createPost(request));
+  }
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/BoardExceptionHandler.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/BoardExceptionHandler.java
@@ -1,0 +1,80 @@
+package kr.co.computermate.scmrft.board.api;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import kr.co.computermate.scmrft.board.service.BoardApiException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice(assignableTypes = BoardController.class)
+public class BoardExceptionHandler {
+  @ExceptionHandler(BoardApiException.class)
+  public ResponseEntity<ApiErrorResponse> handleBoardApiException(
+      BoardApiException ex,
+      HttpServletRequest request
+  ) {
+    return build(request, ex.getStatus(), ex.getCode(), ex.getMessage(), List.of());
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiErrorResponse> handleValidationError(
+      MethodArgumentNotValidException ex,
+      HttpServletRequest request
+  ) {
+    List<ApiErrorResponse.FieldErrorItem> details = ex.getBindingResult().getFieldErrors().stream()
+        .map(fieldError -> new ApiErrorResponse.FieldErrorItem(fieldError.getField(), fieldError.getDefaultMessage()))
+        .toList();
+    return build(request, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Validation failed.", details);
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ApiErrorResponse> handleTypeMismatch(HttpServletRequest request) {
+    return build(request, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Invalid query parameter type.", List.of());
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ApiErrorResponse> handleMalformedPayload(HttpServletRequest request) {
+    return build(request, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Malformed request payload.", List.of());
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiErrorResponse> handleUnexpected(HttpServletRequest request) {
+    return build(request, HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "Unexpected error occurred.", List.of());
+  }
+
+  private ResponseEntity<ApiErrorResponse> build(
+      HttpServletRequest request,
+      HttpStatus status,
+      String code,
+      String message,
+      List<ApiErrorResponse.FieldErrorItem> details
+  ) {
+    String traceId = resolveTraceId(request);
+    ApiErrorResponse body = new ApiErrorResponse(
+        code,
+        message,
+        traceId,
+        request.getRequestURI(),
+        Instant.now(),
+        details
+    );
+
+    return ResponseEntity.status(status)
+        .header("X-Trace-Id", traceId)
+        .header(HttpHeaders.CONTENT_TYPE, "application/json")
+        .body(body);
+  }
+
+  private String resolveTraceId(HttpServletRequest request) {
+    String traceId = request.getHeader("X-Trace-Id");
+    return traceId == null || traceId.isBlank() ? UUID.randomUUID().toString() : traceId;
+  }
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/BoardPostDetailResponse.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/BoardPostDetailResponse.java
@@ -1,0 +1,16 @@
+package kr.co.computermate.scmrft.board.api;
+
+import java.time.Instant;
+import java.util.List;
+
+public record BoardPostDetailResponse(
+    String postId,
+    String boardType,
+    String title,
+    String status,
+    String createdBy,
+    Instant createdAt,
+    String content,
+    List<AttachmentRefResponse> attachments
+) {
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/BoardPostSummaryResponse.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/BoardPostSummaryResponse.java
@@ -1,0 +1,13 @@
+package kr.co.computermate.scmrft.board.api;
+
+import java.time.Instant;
+
+public record BoardPostSummaryResponse(
+    String postId,
+    String boardType,
+    String title,
+    String status,
+    String createdBy,
+    Instant createdAt
+) {
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/CreateBoardPostRequest.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/CreateBoardPostRequest.java
@@ -1,0 +1,23 @@
+package kr.co.computermate.scmrft.board.api;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record CreateBoardPostRequest(
+    @NotBlank(message = "boardType is required.")
+    String boardType,
+    @NotBlank(message = "title is required.")
+    @Size(max = 200, message = "title must be less than or equal to 200 characters.")
+    String title,
+    @NotBlank(message = "content is required.")
+    @Size(max = 10000, message = "content must be less than or equal to 10000 characters.")
+    String content,
+    @NotBlank(message = "createdBy is required.")
+    @Size(max = 40, message = "createdBy must be less than or equal to 40 characters.")
+    String createdBy,
+    @Valid
+    List<AttachmentRefRequest> attachments
+) {
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/CreateBoardPostResponse.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/CreateBoardPostResponse.java
@@ -1,0 +1,9 @@
+package kr.co.computermate.scmrft.board.api;
+
+import java.time.Instant;
+
+public record CreateBoardPostResponse(
+    String postId,
+    Instant createdAt
+) {
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/PageMetaResponse.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/PageMetaResponse.java
@@ -1,0 +1,10 @@
+package kr.co.computermate.scmrft.board.api;
+
+public record PageMetaResponse(
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean hasNext
+) {
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/api/SearchBoardPostsResponse.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/api/SearchBoardPostsResponse.java
@@ -1,0 +1,9 @@
+package kr.co.computermate.scmrft.board.api;
+
+import java.util.List;
+
+public record SearchBoardPostsResponse(
+    List<BoardPostSummaryResponse> items,
+    PageMetaResponse page
+) {
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/repository/BoardAttachmentRepository.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/repository/BoardAttachmentRepository.java
@@ -1,0 +1,49 @@
+package kr.co.computermate.scmrft.board.repository;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BoardAttachmentRepository {
+  private final JdbcClient jdbcClient;
+
+  public BoardAttachmentRepository(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  public void saveAttachments(UUID postId, List<UUID> fileIds) {
+    if (fileIds == null || fileIds.isEmpty()) {
+      return;
+    }
+
+    for (UUID fileId : fileIds) {
+      jdbcClient.sql("""
+              INSERT INTO dbo.board_post_attachments(post_id, file_id, created_at)
+              VALUES (:postId, :fileId, CURRENT_TIMESTAMP)
+          """)
+          .param("postId", postId)
+          .param("fileId", fileId)
+          .update();
+    }
+  }
+
+  public List<UUID> findFileIdsByPostId(UUID postId) {
+    return jdbcClient.sql("""
+            SELECT file_id
+            FROM dbo.board_post_attachments
+            WHERE post_id = :postId
+            ORDER BY file_id
+        """)
+        .param("postId", postId)
+        .query((rs, rowNum) -> {
+          Object value = rs.getObject("file_id");
+          if (value instanceof UUID uuid) {
+            return uuid;
+          }
+          return UUID.fromString(String.valueOf(value));
+        })
+        .list();
+  }
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/repository/BoardPostEntity.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/repository/BoardPostEntity.java
@@ -1,0 +1,15 @@
+package kr.co.computermate.scmrft.board.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record BoardPostEntity(
+    UUID postId,
+    String boardType,
+    String title,
+    String content,
+    String status,
+    String createdBy,
+    Instant createdAt
+) {
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/repository/BoardPostRepository.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/repository/BoardPostRepository.java
@@ -1,0 +1,116 @@
+package kr.co.computermate.scmrft.board.repository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BoardPostRepository {
+  private final JdbcClient jdbcClient;
+
+  public BoardPostRepository(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  public BoardPostSearchResult search(String boardType, String keywordPrefix, int offset, int size) {
+    Long total = jdbcClient.sql("""
+            SELECT COUNT(*) AS total
+            FROM dbo.board_posts
+            WHERE (:boardType IS NULL OR category_code = :boardType)
+              AND (:keywordPrefix IS NULL OR title LIKE :keywordPrefix)
+        """)
+        .param("boardType", boardType)
+        .param("keywordPrefix", keywordPrefix)
+        .query(Long.class)
+        .single();
+
+    List<BoardPostEntity> items = jdbcClient.sql("""
+            SELECT post_id, category_code, title, content, status, writer_member_id, created_at
+            FROM dbo.board_posts
+            WHERE (:boardType IS NULL OR category_code = :boardType)
+              AND (:keywordPrefix IS NULL OR title LIKE :keywordPrefix)
+            ORDER BY created_at DESC, post_id DESC
+            OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY
+        """)
+        .param("boardType", boardType)
+        .param("keywordPrefix", keywordPrefix)
+        .param("offset", offset)
+        .param("size", size)
+        .query((rs, rowNum) -> new BoardPostEntity(
+            toUuid(rs.getObject("post_id")),
+            rs.getString("category_code"),
+            rs.getString("title"),
+            rs.getString("content"),
+            rs.getString("status"),
+            rs.getString("writer_member_id"),
+            toInstant(rs.getTimestamp("created_at"))
+        ))
+        .list();
+
+    return new BoardPostSearchResult(items, total == null ? 0L : total);
+  }
+
+  public Optional<BoardPostEntity> findById(UUID postId) {
+    List<BoardPostEntity> rows = jdbcClient.sql("""
+            SELECT post_id, category_code, title, content, status, writer_member_id, created_at
+            FROM dbo.board_posts
+            WHERE post_id = :postId
+        """)
+        .param("postId", postId)
+        .query((rs, rowNum) -> new BoardPostEntity(
+            toUuid(rs.getObject("post_id")),
+            rs.getString("category_code"),
+            rs.getString("title"),
+            rs.getString("content"),
+            rs.getString("status"),
+            rs.getString("writer_member_id"),
+            toInstant(rs.getTimestamp("created_at"))
+        ))
+        .list();
+
+    return rows.stream().findFirst();
+  }
+
+  public BoardPostEntity create(String boardType, String title, String content, String createdBy, boolean isNotice) {
+    UUID postId = UUID.randomUUID();
+    Instant now = Instant.now();
+    int inserted = jdbcClient.sql("""
+            INSERT INTO dbo.board_posts (
+                post_id, category_code, title, content, writer_member_id, is_notice, status, created_at, updated_at
+            ) VALUES (
+                :postId, :boardType, :title, :content, :createdBy, :isNotice, :status, :createdAt, :updatedAt
+            )
+        """)
+        .param("postId", postId)
+        .param("boardType", boardType)
+        .param("title", title)
+        .param("content", content)
+        .param("createdBy", createdBy)
+        .param("isNotice", isNotice ? 1 : 0)
+        .param("status", "ACTIVE")
+        .param("createdAt", Timestamp.from(now))
+        .param("updatedAt", Timestamp.from(now))
+        .update();
+
+    if (inserted != 1) {
+      throw new IllegalStateException("failed to create board post.");
+    }
+
+    return new BoardPostEntity(postId, boardType, title, content, "ACTIVE", createdBy, now);
+  }
+
+  private Instant toInstant(Timestamp timestamp) {
+    return timestamp == null ? null : timestamp.toInstant();
+  }
+
+  private UUID toUuid(Object value) {
+    if (value instanceof UUID uuid) {
+      return uuid;
+    }
+    return UUID.fromString(String.valueOf(value));
+  }
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/repository/BoardPostSearchResult.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/repository/BoardPostSearchResult.java
@@ -1,0 +1,9 @@
+package kr.co.computermate.scmrft.board.repository;
+
+import java.util.List;
+
+public record BoardPostSearchResult(
+    List<BoardPostEntity> items,
+    long total
+) {
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/service/BoardApiException.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/service/BoardApiException.java
@@ -1,0 +1,50 @@
+package kr.co.computermate.scmrft.board.service;
+
+import org.springframework.http.HttpStatus;
+
+public class BoardApiException extends RuntimeException {
+  private final HttpStatus status;
+  private final String code;
+
+  public BoardApiException(HttpStatus status, String code, String message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+
+  public HttpStatus getStatus() {
+    return status;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public static BoardApiException badRequest(String message) {
+    return new BoardApiException(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message);
+  }
+
+  public static BoardApiException unauthorized(String message) {
+    return new BoardApiException(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", message);
+  }
+
+  public static BoardApiException forbidden(String message) {
+    return new BoardApiException(HttpStatus.FORBIDDEN, "FORBIDDEN", message);
+  }
+
+  public static BoardApiException notFound(String message) {
+    return new BoardApiException(HttpStatus.NOT_FOUND, "NOT_FOUND", message);
+  }
+
+  public static BoardApiException failedDependency(String message) {
+    return new BoardApiException(HttpStatus.FAILED_DEPENDENCY, "DEPENDENCY_FAILED", message);
+  }
+
+  public static BoardApiException badGateway(String message) {
+    return new BoardApiException(HttpStatus.BAD_GATEWAY, "BAD_GATEWAY", message);
+  }
+
+  public static BoardApiException upstreamTimeout(String message) {
+    return new BoardApiException(HttpStatus.GATEWAY_TIMEOUT, "UPSTREAM_TIMEOUT", message);
+  }
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/service/BoardFileClient.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/service/BoardFileClient.java
@@ -1,0 +1,70 @@
+package kr.co.computermate.scmrft.board.service;
+
+import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+@Component
+public class BoardFileClient {
+  private final RestClient restClient;
+
+  public BoardFileClient(@Value("${board.file-service.base-url:http://localhost:8087}") String baseUrl) {
+    this.restClient = RestClient.builder()
+        .baseUrl(baseUrl)
+        .build();
+  }
+
+  public void validateAttachments(List<UUID> fileIds) {
+    if (fileIds == null || fileIds.isEmpty()) {
+      return;
+    }
+
+    for (UUID fileId : fileIds) {
+      try {
+        restClient.get()
+            .uri("/api/file/v1/files/{fileId}", fileId)
+            .retrieve()
+            .toBodilessEntity();
+      }
+      catch (RestClientResponseException ex) {
+        int status = ex.getStatusCode().value();
+        if (status >= 500) {
+          throw BoardApiException.badGateway("file service is unavailable.");
+        }
+        throw BoardApiException.failedDependency("attachment validation failed.");
+      }
+      catch (ResourceAccessException ex) {
+        if (ex.getCause() instanceof SocketTimeoutException) {
+          throw BoardApiException.upstreamTimeout("file service timeout.");
+        }
+        throw BoardApiException.badGateway("file service connection failed.");
+      }
+    }
+  }
+
+  public String tryResolveFileName(UUID fileId) {
+    try {
+      FileMetadataResponse response = restClient.get()
+          .uri("/api/file/v1/files/{fileId}", fileId)
+          .retrieve()
+          .body(FileMetadataResponse.class);
+      return response == null ? null : response.originalName();
+    }
+    catch (Exception ignored) {
+      return null;
+    }
+  }
+
+  private record FileMetadataResponse(
+      String fileId,
+      String domainKey,
+      String originalName,
+      String storagePath
+  ) {
+  }
+}

--- a/services/board/src/main/java/kr/co/computermate/scmrft/board/service/BoardService.java
+++ b/services/board/src/main/java/kr/co/computermate/scmrft/board/service/BoardService.java
@@ -1,0 +1,186 @@
+package kr.co.computermate.scmrft.board.service;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import kr.co.computermate.scmrft.board.api.AttachmentRefRequest;
+import kr.co.computermate.scmrft.board.api.AttachmentRefResponse;
+import kr.co.computermate.scmrft.board.api.BoardPostDetailResponse;
+import kr.co.computermate.scmrft.board.api.BoardPostSummaryResponse;
+import kr.co.computermate.scmrft.board.api.CreateBoardPostRequest;
+import kr.co.computermate.scmrft.board.api.CreateBoardPostResponse;
+import kr.co.computermate.scmrft.board.api.PageMetaResponse;
+import kr.co.computermate.scmrft.board.api.SearchBoardPostsResponse;
+import kr.co.computermate.scmrft.board.repository.BoardAttachmentRepository;
+import kr.co.computermate.scmrft.board.repository.BoardPostEntity;
+import kr.co.computermate.scmrft.board.repository.BoardPostRepository;
+import kr.co.computermate.scmrft.board.repository.BoardPostSearchResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class BoardService {
+  private static final int MAX_PAGE_SIZE = 200;
+
+  private final BoardPostRepository boardPostRepository;
+  private final BoardAttachmentRepository boardAttachmentRepository;
+  private final BoardFileClient boardFileClient;
+
+  public BoardService(
+      BoardPostRepository boardPostRepository,
+      BoardAttachmentRepository boardAttachmentRepository,
+      BoardFileClient boardFileClient
+  ) {
+    this.boardPostRepository = boardPostRepository;
+    this.boardAttachmentRepository = boardAttachmentRepository;
+    this.boardFileClient = boardFileClient;
+  }
+
+  @Transactional(readOnly = true, timeout = 2)
+  public SearchBoardPostsResponse searchPosts(String boardType, String keyword, int page, int size) {
+    validatePaging(page, size);
+    String normalizedBoardType = normalizeBoardType(boardType);
+    String keywordPrefix = normalizeKeywordPrefix(keyword);
+
+    BoardPostSearchResult result = boardPostRepository.search(normalizedBoardType, keywordPrefix, page * size, size);
+
+    List<BoardPostSummaryResponse> items = result.items().stream()
+        .map(this::toSummaryResponse)
+        .toList();
+
+    int totalPages = (int) Math.ceil(result.total() / (double) size);
+    PageMetaResponse pageMeta = new PageMetaResponse(page, size, result.total(), totalPages, page + 1 < totalPages);
+
+    return new SearchBoardPostsResponse(items, pageMeta);
+  }
+
+  @Transactional(readOnly = true, timeout = 2)
+  public BoardPostDetailResponse getPostById(String postId) {
+    UUID normalizedPostId = parseUuid(postId, "postId is invalid.");
+    BoardPostEntity post = boardPostRepository.findById(normalizedPostId)
+        .orElseThrow(() -> BoardApiException.notFound("Post not found."));
+
+    List<AttachmentRefResponse> attachments = boardAttachmentRepository.findFileIdsByPostId(post.postId()).stream()
+        .map(fileId -> new AttachmentRefResponse(fileId.toString(), boardFileClient.tryResolveFileName(fileId)))
+        .toList();
+
+    return new BoardPostDetailResponse(
+        post.postId().toString(),
+        post.boardType(),
+        post.title(),
+        toApiStatus(post.status()),
+        post.createdBy(),
+        post.createdAt(),
+        post.content(),
+        attachments
+    );
+  }
+
+  @Transactional(timeout = 3, isolation = Isolation.READ_COMMITTED)
+  public CreateBoardPostResponse createPost(CreateBoardPostRequest request) {
+    String boardType = normalizeBoardType(request.boardType());
+    String createdBy = requireValue(request.createdBy(), "createdBy is required.");
+    String title = requireValue(request.title(), "title is required.");
+    String content = requireValue(request.content(), "content is required.");
+
+    List<UUID> fileIds = parseFileIds(request.attachments());
+    boardFileClient.validateAttachments(fileIds);
+
+    BoardPostEntity created = boardPostRepository.create(
+        boardType,
+        title,
+        content,
+        createdBy,
+        "NOTICE".equals(boardType)
+    );
+    boardAttachmentRepository.saveAttachments(created.postId(), fileIds);
+
+    return new CreateBoardPostResponse(created.postId().toString(), created.createdAt());
+  }
+
+  private BoardPostSummaryResponse toSummaryResponse(BoardPostEntity entity) {
+    return new BoardPostSummaryResponse(
+        entity.postId().toString(),
+        entity.boardType(),
+        entity.title(),
+        toApiStatus(entity.status()),
+        entity.createdBy(),
+        entity.createdAt()
+    );
+  }
+
+  private String toApiStatus(String dbStatus) {
+    if (dbStatus == null) {
+      return "DRAFT";
+    }
+    return switch (dbStatus.toUpperCase(Locale.ROOT)) {
+      case "ACTIVE" -> "PUBLISHED";
+      case "DELETED" -> "CLOSED";
+      case "HIDDEN" -> "DRAFT";
+      default -> "DRAFT";
+    };
+  }
+
+  private List<UUID> parseFileIds(List<AttachmentRefRequest> attachments) {
+    if (attachments == null || attachments.isEmpty()) {
+      return List.of();
+    }
+
+    return attachments.stream()
+        .map(AttachmentRefRequest::fileId)
+        .map(fileId -> parseUuid(fileId, "fileId is invalid."))
+        .toList();
+  }
+
+  private UUID parseUuid(String value, String message) {
+    try {
+      return UUID.fromString(requireValue(value, message));
+    }
+    catch (IllegalArgumentException ex) {
+      throw BoardApiException.badRequest(message);
+    }
+  }
+
+  private void validatePaging(int page, int size) {
+    if (page < 0) {
+      throw BoardApiException.badRequest("page must be greater than or equal to 0.");
+    }
+    if (size < 1 || size > MAX_PAGE_SIZE) {
+      throw BoardApiException.badRequest("size must be between 1 and 200.");
+    }
+  }
+
+  private String normalizeBoardType(String boardType) {
+    String normalized = normalizeToNull(boardType);
+    if (normalized == null) {
+      return null;
+    }
+    String upper = normalized.toUpperCase(Locale.ROOT);
+    if (!"NOTICE".equals(upper) && !"GENERAL".equals(upper) && !"QUALITY".equals(upper)) {
+      throw BoardApiException.badRequest("boardType must be NOTICE, GENERAL, or QUALITY.");
+    }
+    return upper;
+  }
+
+  private String normalizeKeywordPrefix(String keyword) {
+    String normalized = normalizeToNull(keyword);
+    return normalized == null ? null : normalized + "%";
+  }
+
+  private String normalizeToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private String requireValue(String value, String message) {
+    String normalized = normalizeToNull(value);
+    if (normalized == null) {
+      throw BoardApiException.badRequest(message);
+    }
+    return normalized;
+  }
+}

--- a/services/board/src/main/resources/application.yml
+++ b/services/board/src/main/resources/application.yml
@@ -18,3 +18,6 @@ management:
     web:
       exposure:
         include: health,info,prometheus
+board:
+  file-service:
+    base-url: ${BOARD_FILE_SERVICE_BASE_URL:http://localhost:8087}

--- a/services/board/src/test/java/kr/co/computermate/scmrft/board/repository/BoardPostRepositoryIntegrationTests.java
+++ b/services/board/src/test/java/kr/co/computermate/scmrft/board/repository/BoardPostRepositoryIntegrationTests.java
@@ -1,0 +1,48 @@
+package kr.co.computermate.scmrft.board.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+@SpringBootTest
+class BoardPostRepositoryIntegrationTests {
+  @Autowired
+  private JdbcClient jdbcClient;
+
+  @Autowired
+  private BoardPostRepository boardPostRepository;
+
+  @BeforeEach
+  void setUpSchema() {
+    jdbcClient.sql("CREATE SCHEMA IF NOT EXISTS dbo").update();
+    jdbcClient.sql("""
+            CREATE TABLE IF NOT EXISTS dbo.board_posts (
+                post_id UUID PRIMARY KEY,
+                category_code VARCHAR(30) NOT NULL,
+                title VARCHAR(200) NOT NULL,
+                content VARCHAR(4000),
+                writer_member_id VARCHAR(50),
+                is_notice BOOLEAN NOT NULL,
+                status VARCHAR(20) NOT NULL,
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL
+            )
+        """).update();
+    jdbcClient.sql("DELETE FROM dbo.board_posts").update();
+  }
+
+  @Test
+  void createAndSearchWorks() {
+    boardPostRepository.create("GENERAL", "title", "content", "writer", false);
+
+    BoardPostSearchResult result = boardPostRepository.search("GENERAL", "tit%", 0, 20);
+
+    assertThat(result.total()).isEqualTo(1L);
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().get(0).title()).isEqualTo("title");
+  }
+}

--- a/services/board/src/test/java/kr/co/computermate/scmrft/board/service/BoardServiceTests.java
+++ b/services/board/src/test/java/kr/co/computermate/scmrft/board/service/BoardServiceTests.java
@@ -1,0 +1,69 @@
+package kr.co.computermate.scmrft.board.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import kr.co.computermate.scmrft.board.api.AttachmentRefRequest;
+import kr.co.computermate.scmrft.board.api.BoardPostDetailResponse;
+import kr.co.computermate.scmrft.board.api.CreateBoardPostRequest;
+import kr.co.computermate.scmrft.board.repository.BoardAttachmentRepository;
+import kr.co.computermate.scmrft.board.repository.BoardPostEntity;
+import kr.co.computermate.scmrft.board.repository.BoardPostRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BoardServiceTests {
+  @Mock
+  private BoardPostRepository boardPostRepository;
+  @Mock
+  private BoardAttachmentRepository boardAttachmentRepository;
+  @Mock
+  private BoardFileClient boardFileClient;
+
+  @Test
+  void createPostReturnsDependencyErrorWhenAttachmentValidationFails() {
+    BoardService service = new BoardService(boardPostRepository, boardAttachmentRepository, boardFileClient);
+    UUID fileId = UUID.randomUUID();
+    doThrow(BoardApiException.failedDependency("attachment validation failed."))
+        .when(boardFileClient).validateAttachments(List.of(fileId));
+
+    CreateBoardPostRequest request = new CreateBoardPostRequest(
+        "GENERAL",
+        "title",
+        "content",
+        "writer",
+        List.of(new AttachmentRefRequest(fileId.toString()))
+    );
+
+    assertThatThrownBy(() -> service.createPost(request))
+        .isInstanceOf(BoardApiException.class)
+        .hasMessageContaining("attachment validation failed");
+  }
+
+  @Test
+  void getPostByIdReturnsDetailEvenWhenFileMetadataLookupFails() {
+    BoardService service = new BoardService(boardPostRepository, boardAttachmentRepository, boardFileClient);
+    UUID postId = UUID.randomUUID();
+    UUID fileId = UUID.randomUUID();
+    when(boardPostRepository.findById(postId)).thenReturn(Optional.of(
+        new BoardPostEntity(postId, "GENERAL", "title", "content", "ACTIVE", "writer", Instant.now())
+    ));
+    when(boardAttachmentRepository.findFileIdsByPostId(postId)).thenReturn(List.of(fileId));
+    when(boardFileClient.tryResolveFileName(fileId)).thenReturn(null);
+
+    BoardPostDetailResponse response = service.getPostById(postId.toString());
+
+    assertThat(response.postId()).isEqualTo(postId.toString());
+    assertThat(response.attachments()).hasSize(1);
+    assertThat(response.attachments().get(0).fileName()).isNull();
+  }
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/ApiErrorResponse.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/ApiErrorResponse.java
@@ -1,0 +1,16 @@
+package kr.co.computermate.scmrft.qualitydoc.api;
+
+import java.time.Instant;
+import java.util.List;
+
+public record ApiErrorResponse(
+    String code,
+    String message,
+    String traceId,
+    String path,
+    Instant timestamp,
+    List<FieldErrorItem> details
+) {
+  public record FieldErrorItem(String field, String reason) {
+  }
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/PageMetaResponse.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/PageMetaResponse.java
@@ -1,0 +1,10 @@
+package kr.co.computermate.scmrft.qualitydoc.api;
+
+public record PageMetaResponse(
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean hasNext
+) {
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocController.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocController.java
@@ -1,0 +1,44 @@
+package kr.co.computermate.scmrft.qualitydoc.api;
+
+import jakarta.validation.Valid;
+import kr.co.computermate.scmrft.qualitydoc.service.QualityDocService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/quality-doc/v1")
+public class QualityDocController {
+  private final QualityDocService qualityDocService;
+
+  public QualityDocController(QualityDocService qualityDocService) {
+    this.qualityDocService = qualityDocService;
+  }
+
+  @GetMapping("/documents")
+  public SearchQualityDocumentsResponse searchDocuments(
+      @RequestParam(value = "status", required = false) String status,
+      @RequestParam(value = "keyword", required = false) String keyword,
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "size", defaultValue = "20") int size
+  ) {
+    return qualityDocService.searchDocuments(status, keyword, page, size);
+  }
+
+  @GetMapping("/documents/{documentId}")
+  public QualityDocumentDetailResponse getDocumentById(@PathVariable("documentId") String documentId) {
+    return qualityDocService.getDocumentById(documentId);
+  }
+
+  @PutMapping("/documents/{documentId}/ack")
+  public QualityDocumentAckResponse acknowledge(
+      @PathVariable("documentId") String documentId,
+      @Valid @RequestBody QualityDocumentAckRequest request
+  ) {
+    return qualityDocService.acknowledge(documentId, request);
+  }
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocExceptionHandler.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocExceptionHandler.java
@@ -1,0 +1,80 @@
+package kr.co.computermate.scmrft.qualitydoc.api;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import kr.co.computermate.scmrft.qualitydoc.service.QualityDocApiException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice(assignableTypes = QualityDocController.class)
+public class QualityDocExceptionHandler {
+  @ExceptionHandler(QualityDocApiException.class)
+  public ResponseEntity<ApiErrorResponse> handleQualityDocApiException(
+      QualityDocApiException ex,
+      HttpServletRequest request
+  ) {
+    return build(request, ex.getStatus(), ex.getCode(), ex.getMessage(), List.of());
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiErrorResponse> handleValidationError(
+      MethodArgumentNotValidException ex,
+      HttpServletRequest request
+  ) {
+    List<ApiErrorResponse.FieldErrorItem> details = ex.getBindingResult().getFieldErrors().stream()
+        .map(fieldError -> new ApiErrorResponse.FieldErrorItem(fieldError.getField(), fieldError.getDefaultMessage()))
+        .toList();
+    return build(request, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Validation failed.", details);
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ApiErrorResponse> handleTypeMismatch(HttpServletRequest request) {
+    return build(request, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Invalid query parameter type.", List.of());
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ApiErrorResponse> handleMalformedPayload(HttpServletRequest request) {
+    return build(request, HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Malformed request payload.", List.of());
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiErrorResponse> handleUnexpected(HttpServletRequest request) {
+    return build(request, HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "Unexpected error occurred.", List.of());
+  }
+
+  private ResponseEntity<ApiErrorResponse> build(
+      HttpServletRequest request,
+      HttpStatus status,
+      String code,
+      String message,
+      List<ApiErrorResponse.FieldErrorItem> details
+  ) {
+    String traceId = resolveTraceId(request);
+    ApiErrorResponse body = new ApiErrorResponse(
+        code,
+        message,
+        traceId,
+        request.getRequestURI(),
+        Instant.now(),
+        details
+    );
+
+    return ResponseEntity.status(status)
+        .header("X-Trace-Id", traceId)
+        .header(HttpHeaders.CONTENT_TYPE, "application/json")
+        .body(body);
+  }
+
+  private String resolveTraceId(HttpServletRequest request) {
+    String traceId = request.getHeader("X-Trace-Id");
+    return traceId == null || traceId.isBlank() ? UUID.randomUUID().toString() : traceId;
+  }
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocumentAckRequest.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocumentAckRequest.java
@@ -1,0 +1,15 @@
+package kr.co.computermate.scmrft.qualitydoc.api;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record QualityDocumentAckRequest(
+    @NotBlank(message = "memberId is required.")
+    @Size(max = 40, message = "memberId must be less than or equal to 40 characters.")
+    String memberId,
+    @NotBlank(message = "ackType is required.")
+    String ackType,
+    @Size(max = 500, message = "comment must be less than or equal to 500 characters.")
+    String comment
+) {
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocumentAckResponse.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocumentAckResponse.java
@@ -1,0 +1,13 @@
+package kr.co.computermate.scmrft.qualitydoc.api;
+
+import java.time.Instant;
+
+public record QualityDocumentAckResponse(
+    String documentId,
+    String memberId,
+    String ackType,
+    boolean acknowledged,
+    Instant acknowledgedAt,
+    boolean duplicateRequest
+) {
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocumentDetailResponse.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocumentDetailResponse.java
@@ -1,0 +1,14 @@
+package kr.co.computermate.scmrft.qualitydoc.api;
+
+import java.time.Instant;
+
+public record QualityDocumentDetailResponse(
+    String documentId,
+    String title,
+    String status,
+    Instant issuedAt,
+    String contentUrl,
+    String version,
+    boolean requiresAck
+) {
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocumentSummaryResponse.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/QualityDocumentSummaryResponse.java
@@ -1,0 +1,11 @@
+package kr.co.computermate.scmrft.qualitydoc.api;
+
+import java.time.Instant;
+
+public record QualityDocumentSummaryResponse(
+    String documentId,
+    String title,
+    String status,
+    Instant issuedAt
+) {
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/SearchQualityDocumentsResponse.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/api/SearchQualityDocumentsResponse.java
@@ -1,0 +1,9 @@
+package kr.co.computermate.scmrft.qualitydoc.api;
+
+import java.util.List;
+
+public record SearchQualityDocumentsResponse(
+    List<QualityDocumentSummaryResponse> items,
+    PageMetaResponse page
+) {
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentAckEntity.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentAckEntity.java
@@ -1,0 +1,12 @@
+package kr.co.computermate.scmrft.qualitydoc.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record QualityDocumentAckEntity(
+    UUID documentId,
+    String memberId,
+    String ackType,
+    Instant ackAt
+) {
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentAckRepository.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentAckRepository.java
@@ -1,0 +1,69 @@
+package kr.co.computermate.scmrft.qualitydoc.repository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class QualityDocumentAckRepository {
+  private final JdbcClient jdbcClient;
+
+  public QualityDocumentAckRepository(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  public Optional<QualityDocumentAckEntity> findByDocumentIdAndMemberId(UUID documentId, String memberId) {
+    List<QualityDocumentAckEntity> rows = jdbcClient.sql("""
+            SELECT document_id, member_id, ack_type, ack_at
+            FROM dbo.quality_document_acks
+            WHERE document_id = :documentId
+              AND member_id = :memberId
+        """)
+        .param("documentId", documentId)
+        .param("memberId", memberId)
+        .query((rs, rowNum) -> new QualityDocumentAckEntity(
+            toUuid(rs.getObject("document_id")),
+            rs.getString("member_id"),
+            rs.getString("ack_type"),
+            toInstant(rs.getTimestamp("ack_at"))
+        ))
+        .list();
+
+    return rows.stream().findFirst();
+  }
+
+  public QualityDocumentAckEntity insert(UUID documentId, String memberId, String ackType, Instant ackAt) {
+    int inserted = jdbcClient.sql("""
+            INSERT INTO dbo.quality_document_acks(
+                document_id, member_id, ack_type, ack_at, created_at
+            ) VALUES (
+                :documentId, :memberId, :ackType, :ackAt, CURRENT_TIMESTAMP
+            )
+        """)
+        .param("documentId", documentId)
+        .param("memberId", memberId)
+        .param("ackType", ackType)
+        .param("ackAt", Timestamp.from(ackAt))
+        .update();
+
+    if (inserted != 1) {
+      throw new IllegalStateException("failed to insert quality document ack.");
+    }
+    return new QualityDocumentAckEntity(documentId, memberId, ackType, ackAt);
+  }
+
+  private Instant toInstant(Timestamp value) {
+    return value == null ? null : value.toInstant();
+  }
+
+  private UUID toUuid(Object value) {
+    if (value instanceof UUID uuid) {
+      return uuid;
+    }
+    return UUID.fromString(String.valueOf(value));
+  }
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentEntity.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentEntity.java
@@ -1,0 +1,13 @@
+package kr.co.computermate.scmrft.qualitydoc.repository;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record QualityDocumentEntity(
+    UUID documentId,
+    String title,
+    String documentType,
+    String status,
+    Instant issuedAt
+) {
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentRepository.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentRepository.java
@@ -1,0 +1,83 @@
+package kr.co.computermate.scmrft.qualitydoc.repository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class QualityDocumentRepository {
+  private final JdbcClient jdbcClient;
+
+  public QualityDocumentRepository(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  public QualityDocumentSearchResult search(String statusFilter, String keywordPrefix, int offset, int size) {
+    Long total = jdbcClient.sql("""
+            SELECT COUNT(*) AS total
+            FROM dbo.quality_documents
+            WHERE (:statusFilter IS NULL OR status = :statusFilter)
+              AND (:keywordPrefix IS NULL OR title LIKE :keywordPrefix)
+        """)
+        .param("statusFilter", statusFilter)
+        .param("keywordPrefix", keywordPrefix)
+        .query(Long.class)
+        .single();
+
+    List<QualityDocumentEntity> items = jdbcClient.sql("""
+            SELECT document_id, title, document_type, status, issued_at
+            FROM dbo.quality_documents
+            WHERE (:statusFilter IS NULL OR status = :statusFilter)
+              AND (:keywordPrefix IS NULL OR title LIKE :keywordPrefix)
+            ORDER BY issued_at DESC, document_id DESC
+            OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY
+        """)
+        .param("statusFilter", statusFilter)
+        .param("keywordPrefix", keywordPrefix)
+        .param("offset", offset)
+        .param("size", size)
+        .query((rs, rowNum) -> new QualityDocumentEntity(
+            toUuid(rs.getObject("document_id")),
+            rs.getString("title"),
+            rs.getString("document_type"),
+            rs.getString("status"),
+            toInstant(rs.getTimestamp("issued_at"))
+        ))
+        .list();
+
+    return new QualityDocumentSearchResult(items, total == null ? 0L : total);
+  }
+
+  public Optional<QualityDocumentEntity> findById(UUID documentId) {
+    List<QualityDocumentEntity> rows = jdbcClient.sql("""
+            SELECT document_id, title, document_type, status, issued_at
+            FROM dbo.quality_documents
+            WHERE document_id = :documentId
+        """)
+        .param("documentId", documentId)
+        .query((rs, rowNum) -> new QualityDocumentEntity(
+            toUuid(rs.getObject("document_id")),
+            rs.getString("title"),
+            rs.getString("document_type"),
+            rs.getString("status"),
+            toInstant(rs.getTimestamp("issued_at"))
+        ))
+        .list();
+    return rows.stream().findFirst();
+  }
+
+  private Instant toInstant(Timestamp value) {
+    return value == null ? null : value.toInstant();
+  }
+
+  private UUID toUuid(Object value) {
+    if (value instanceof UUID uuid) {
+      return uuid;
+    }
+    return UUID.fromString(String.valueOf(value));
+  }
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentSearchResult.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentSearchResult.java
@@ -1,0 +1,9 @@
+package kr.co.computermate.scmrft.qualitydoc.repository;
+
+import java.util.List;
+
+public record QualityDocumentSearchResult(
+    List<QualityDocumentEntity> items,
+    long total
+) {
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/service/QualityDocApiException.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/service/QualityDocApiException.java
@@ -1,0 +1,34 @@
+package kr.co.computermate.scmrft.qualitydoc.service;
+
+import org.springframework.http.HttpStatus;
+
+public class QualityDocApiException extends RuntimeException {
+  private final HttpStatus status;
+  private final String code;
+
+  public QualityDocApiException(HttpStatus status, String code, String message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+
+  public HttpStatus getStatus() {
+    return status;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public static QualityDocApiException badRequest(String message) {
+    return new QualityDocApiException(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", message);
+  }
+
+  public static QualityDocApiException notFound(String message) {
+    return new QualityDocApiException(HttpStatus.NOT_FOUND, "NOT_FOUND", message);
+  }
+
+  public static QualityDocApiException conflict(String message) {
+    return new QualityDocApiException(HttpStatus.CONFLICT, "CONFLICT", message);
+  }
+}

--- a/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/service/QualityDocService.java
+++ b/services/quality-doc/src/main/java/kr/co/computermate/scmrft/qualitydoc/service/QualityDocService.java
@@ -1,0 +1,202 @@
+package kr.co.computermate.scmrft.qualitydoc.service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import kr.co.computermate.scmrft.qualitydoc.api.PageMetaResponse;
+import kr.co.computermate.scmrft.qualitydoc.api.QualityDocumentAckRequest;
+import kr.co.computermate.scmrft.qualitydoc.api.QualityDocumentAckResponse;
+import kr.co.computermate.scmrft.qualitydoc.api.QualityDocumentDetailResponse;
+import kr.co.computermate.scmrft.qualitydoc.api.QualityDocumentSummaryResponse;
+import kr.co.computermate.scmrft.qualitydoc.api.SearchQualityDocumentsResponse;
+import kr.co.computermate.scmrft.qualitydoc.repository.QualityDocumentAckEntity;
+import kr.co.computermate.scmrft.qualitydoc.repository.QualityDocumentAckRepository;
+import kr.co.computermate.scmrft.qualitydoc.repository.QualityDocumentEntity;
+import kr.co.computermate.scmrft.qualitydoc.repository.QualityDocumentRepository;
+import kr.co.computermate.scmrft.qualitydoc.repository.QualityDocumentSearchResult;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class QualityDocService {
+  private static final int MAX_PAGE_SIZE = 200;
+
+  private final QualityDocumentRepository qualityDocumentRepository;
+  private final QualityDocumentAckRepository qualityDocumentAckRepository;
+
+  public QualityDocService(
+      QualityDocumentRepository qualityDocumentRepository,
+      QualityDocumentAckRepository qualityDocumentAckRepository
+  ) {
+    this.qualityDocumentRepository = qualityDocumentRepository;
+    this.qualityDocumentAckRepository = qualityDocumentAckRepository;
+  }
+
+  @Transactional(readOnly = true, timeout = 2)
+  public SearchQualityDocumentsResponse searchDocuments(String status, String keyword, int page, int size) {
+    validatePaging(page, size);
+    String dbStatusFilter = toDbStatusFilter(status);
+    String keywordPrefix = normalizeKeywordPrefix(keyword);
+
+    QualityDocumentSearchResult result = qualityDocumentRepository.search(dbStatusFilter, keywordPrefix, page * size, size);
+    List<QualityDocumentSummaryResponse> items = result.items().stream()
+        .map(this::toSummary)
+        .toList();
+
+    int totalPages = (int) Math.ceil(result.total() / (double) size);
+    PageMetaResponse pageMeta = new PageMetaResponse(page, size, result.total(), totalPages, page + 1 < totalPages);
+
+    return new SearchQualityDocumentsResponse(items, pageMeta);
+  }
+
+  @Transactional(readOnly = true, timeout = 2)
+  public QualityDocumentDetailResponse getDocumentById(String documentId) {
+    UUID normalizedDocumentId = parseUuid(documentId, "documentId is invalid.");
+    QualityDocumentEntity entity = qualityDocumentRepository.findById(normalizedDocumentId)
+        .orElseThrow(() -> QualityDocApiException.notFound("Document not found."));
+
+    return new QualityDocumentDetailResponse(
+        entity.documentId().toString(),
+        entity.title(),
+        toApiStatus(entity.status()),
+        entity.issuedAt(),
+        null,
+        null,
+        true
+    );
+  }
+
+  @Transactional(timeout = 3, isolation = Isolation.READ_COMMITTED)
+  public QualityDocumentAckResponse acknowledge(String documentId, QualityDocumentAckRequest request) {
+    UUID normalizedDocumentId = parseUuid(documentId, "documentId is invalid.");
+    String memberId = requireValue(request.memberId(), "memberId is required.");
+    String ackType = normalizeAckType(request.ackType());
+
+    qualityDocumentRepository.findById(normalizedDocumentId)
+        .orElseThrow(() -> QualityDocApiException.notFound("Document not found."));
+
+    QualityDocumentAckEntity existing = qualityDocumentAckRepository
+        .findByDocumentIdAndMemberId(normalizedDocumentId, memberId)
+        .orElse(null);
+    if (existing != null) {
+      if (!ackType.equals(existing.ackType())) {
+        throw QualityDocApiException.conflict("ACK already exists with different ackType.");
+      }
+      return toAckResponse(existing, true);
+    }
+
+    Instant now = Instant.now();
+    try {
+      QualityDocumentAckEntity inserted = qualityDocumentAckRepository.insert(normalizedDocumentId, memberId, ackType, now);
+      return toAckResponse(inserted, false);
+    }
+    catch (DataIntegrityViolationException ex) {
+      QualityDocumentAckEntity concurrent = qualityDocumentAckRepository
+          .findByDocumentIdAndMemberId(normalizedDocumentId, memberId)
+          .orElseThrow(() -> QualityDocApiException.conflict("ACK conflict detected."));
+      if (!ackType.equals(concurrent.ackType())) {
+        throw QualityDocApiException.conflict("ACK already exists with different ackType.");
+      }
+      return toAckResponse(concurrent, true);
+    }
+  }
+
+  private QualityDocumentAckResponse toAckResponse(QualityDocumentAckEntity entity, boolean duplicate) {
+    return new QualityDocumentAckResponse(
+        entity.documentId().toString(),
+        entity.memberId(),
+        entity.ackType(),
+        true,
+        entity.ackAt(),
+        duplicate
+    );
+  }
+
+  private QualityDocumentSummaryResponse toSummary(QualityDocumentEntity entity) {
+    return new QualityDocumentSummaryResponse(
+        entity.documentId().toString(),
+        entity.title(),
+        toApiStatus(entity.status()),
+        entity.issuedAt()
+    );
+  }
+
+  private String toApiStatus(String dbStatus) {
+    if (dbStatus == null) {
+      return "ACTIVE";
+    }
+    return switch (dbStatus.toUpperCase(Locale.ROOT)) {
+      case "ISSUED" -> "ACTIVE";
+      case "RECEIVED" -> "EXPIRED";
+      case "ARCHIVED" -> "ARCHIVED";
+      default -> "ACTIVE";
+    };
+  }
+
+  private String toDbStatusFilter(String apiStatus) {
+    String normalized = normalizeToNull(apiStatus);
+    if (normalized == null) {
+      return null;
+    }
+    return switch (normalized.toUpperCase(Locale.ROOT)) {
+      case "ACTIVE" -> "ISSUED";
+      case "EXPIRED" -> "RECEIVED";
+      case "ARCHIVED" -> "ARCHIVED";
+      default -> throw QualityDocApiException.badRequest("status must be ACTIVE, EXPIRED, or ARCHIVED.");
+    };
+  }
+
+  private String normalizeAckType(String ackType) {
+    String normalized = normalizeToNull(ackType);
+    if (normalized == null) {
+      throw QualityDocApiException.badRequest("ackType is required.");
+    }
+    String upper = normalized.toUpperCase(Locale.ROOT);
+    if (!"READ".equals(upper) && !"CONFIRMED".equals(upper)) {
+      throw QualityDocApiException.badRequest("ackType must be READ or CONFIRMED.");
+    }
+    return upper;
+  }
+
+  private String normalizeKeywordPrefix(String keyword) {
+    String normalized = normalizeToNull(keyword);
+    return normalized == null ? null : normalized + "%";
+  }
+
+  private void validatePaging(int page, int size) {
+    if (page < 0) {
+      throw QualityDocApiException.badRequest("page must be greater than or equal to 0.");
+    }
+    if (size < 1 || size > MAX_PAGE_SIZE) {
+      throw QualityDocApiException.badRequest("size must be between 1 and 200.");
+    }
+  }
+
+  private UUID parseUuid(String value, String message) {
+    try {
+      return UUID.fromString(requireValue(value, message));
+    }
+    catch (IllegalArgumentException ex) {
+      throw QualityDocApiException.badRequest(message);
+    }
+  }
+
+  private String requireValue(String value, String message) {
+    String normalized = normalizeToNull(value);
+    if (normalized == null) {
+      throw QualityDocApiException.badRequest(message);
+    }
+    return normalized;
+  }
+
+  private String normalizeToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/services/quality-doc/src/test/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentAckRepositoryIntegrationTests.java
+++ b/services/quality-doc/src/test/java/kr/co/computermate/scmrft/qualitydoc/repository/QualityDocumentAckRepositoryIntegrationTests.java
@@ -1,0 +1,51 @@
+package kr.co.computermate.scmrft.qualitydoc.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+@SpringBootTest
+class QualityDocumentAckRepositoryIntegrationTests {
+  @Autowired
+  private JdbcClient jdbcClient;
+
+  @Autowired
+  private QualityDocumentAckRepository qualityDocumentAckRepository;
+
+  @BeforeEach
+  void setUpSchema() {
+    jdbcClient.sql("CREATE SCHEMA IF NOT EXISTS dbo").update();
+    jdbcClient.sql("""
+            CREATE TABLE IF NOT EXISTS dbo.quality_document_acks (
+                document_id UUID NOT NULL,
+                member_id VARCHAR(50) NOT NULL,
+                ack_type VARCHAR(20) NOT NULL,
+                ack_at TIMESTAMP NOT NULL,
+                created_at TIMESTAMP NOT NULL,
+                PRIMARY KEY (document_id, member_id)
+            )
+        """).update();
+    jdbcClient.sql("DELETE FROM dbo.quality_document_acks").update();
+  }
+
+  @Test
+  void insertAndFindByDocumentIdAndMemberIdWorks() {
+    UUID documentId = UUID.randomUUID();
+    Instant now = Instant.now();
+    qualityDocumentAckRepository.insert(documentId, "user01", "READ", now);
+
+    QualityDocumentAckEntity entity = qualityDocumentAckRepository
+        .findByDocumentIdAndMemberId(documentId, "user01")
+        .orElseThrow();
+
+    assertThat(entity.documentId()).isEqualTo(documentId);
+    assertThat(entity.memberId()).isEqualTo("user01");
+    assertThat(entity.ackType()).isEqualTo("READ");
+  }
+}

--- a/services/quality-doc/src/test/java/kr/co/computermate/scmrft/qualitydoc/service/QualityDocServiceTests.java
+++ b/services/quality-doc/src/test/java/kr/co/computermate/scmrft/qualitydoc/service/QualityDocServiceTests.java
@@ -1,0 +1,70 @@
+package kr.co.computermate.scmrft.qualitydoc.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import kr.co.computermate.scmrft.qualitydoc.api.QualityDocumentAckRequest;
+import kr.co.computermate.scmrft.qualitydoc.api.QualityDocumentAckResponse;
+import kr.co.computermate.scmrft.qualitydoc.repository.QualityDocumentAckEntity;
+import kr.co.computermate.scmrft.qualitydoc.repository.QualityDocumentAckRepository;
+import kr.co.computermate.scmrft.qualitydoc.repository.QualityDocumentEntity;
+import kr.co.computermate.scmrft.qualitydoc.repository.QualityDocumentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class QualityDocServiceTests {
+  @Mock
+  private QualityDocumentRepository qualityDocumentRepository;
+  @Mock
+  private QualityDocumentAckRepository qualityDocumentAckRepository;
+
+  @Test
+  void acknowledgeReturnsDuplicateWhenSameRequestIsRepeated() {
+    QualityDocService service = new QualityDocService(qualityDocumentRepository, qualityDocumentAckRepository);
+    UUID documentId = UUID.randomUUID();
+    when(qualityDocumentRepository.findById(documentId)).thenReturn(Optional.of(
+        new QualityDocumentEntity(documentId, "doc", "NOTICE", "ISSUED", Instant.now())
+    ));
+    when(qualityDocumentAckRepository.findByDocumentIdAndMemberId(documentId, "user01"))
+        .thenReturn(Optional.of(new QualityDocumentAckEntity(documentId, "user01", "READ", Instant.now())));
+
+    QualityDocumentAckResponse response = service.acknowledge(
+        documentId.toString(),
+        new QualityDocumentAckRequest("user01", "READ", null)
+    );
+
+    assertThat(response.duplicateRequest()).isTrue();
+    verify(qualityDocumentAckRepository, never()).insert(any(), any(), any(), any());
+  }
+
+  @Test
+  void acknowledgeRejectsWhenExistingAckTypeDiffers() {
+    QualityDocService service = new QualityDocService(qualityDocumentRepository, qualityDocumentAckRepository);
+    UUID documentId = UUID.randomUUID();
+    when(qualityDocumentRepository.findById(documentId)).thenReturn(Optional.of(
+        new QualityDocumentEntity(documentId, "doc", "NOTICE", "ISSUED", Instant.now())
+    ));
+    when(qualityDocumentAckRepository.findByDocumentIdAndMemberId(documentId, "user01"))
+        .thenReturn(Optional.of(new QualityDocumentAckEntity(documentId, "user01", "READ", Instant.now())));
+
+    assertThatThrownBy(() -> service.acknowledge(
+        documentId.toString(),
+        new QualityDocumentAckRequest("user01", "CONFIRMED", null)
+    ))
+        .isInstanceOf(QualityDocApiException.class)
+        .hasMessageContaining("different ackType");
+
+    verify(qualityDocumentAckRepository, never()).insert(eq(documentId), eq("user01"), eq("CONFIRMED"), any());
+  }
+}


### PR DESCRIPTION
## Summary
- Implemented Board MVP APIs (list/detail/create)
- Implemented file-service attachment validation with 424/502/504 error mapping
- Implemented Quality-Doc MVP APIs (list/detail/ack)
- Implemented ACK idempotency (documentId + memberId) and conflict handling
- Added migration V6 for quality_document_acks.ack_type

## Gates
- build: PASS
- unit-integration-test: PASS
- contract-test: PASS
- smoke-test: PASS (gateway e2e smoke skipped by default env)
- migration-dry-run: PASS

## Evidence
- runbooks/evidence/SCM-211-20260226-124514/gate-build.log
- runbooks/evidence/SCM-211-20260226-124514/gate-unit-integration.log
- runbooks/evidence/SCM-211-20260226-124514/gate-contract.log
- runbooks/evidence/SCM-211-20260226-124514/gate-smoke.log
- runbooks/evidence/SCM-211-20260226-124514/gate-migration-dry-run.log