### PR TITLE
SCM-213: R1 migration validation execution pack

### DIFF
--- a/migration/reports/R1-report-template.md
+++ b/migration/reports/R1-report-template.md
@@ -1,0 +1,133 @@
+﻿# SCM-213 R1 Validation Report Template
+
+## 1) Run Metadata
+- RunId: `<R1-YYYYMMDD-HHMMSS-ENV>`
+- RunId 규칙:
+  - Prefix: `R1-`
+  - Timestamp: `yyyyMMdd-HHmmss` (KST 기준)
+  - Suffix: `DEV|STG|PRD-REHEARSAL`
+  - 예시: `R1-20260226-153000-STG`
+- 실행환경:
+  - Legacy DB: `<MES_HI_LEGACY>`
+  - Target DB: `<MES_HI>`
+  - Host/Container: `<hostname or container>`
+  - Tool: `sqlcmd` / `SSMS`
+- 실행자:
+  - Dev: `<name>`
+  - Codex: `<name>`
+- 실행시간:
+  - StartedAt: `<yyyy-MM-dd HH:mm:ss>`
+  - EndedAt: `<yyyy-MM-dd HH:mm:ss>`
+  - Duration(min): `<number>`
+
+## 2) SQL 실행 파일 경로
+- `migration/sql/r1-validation/01-auth-validation.sql`
+- `migration/sql/r1-validation/02-member-validation.sql`
+- `migration/sql/r1-validation/03-file-validation.sql`
+- `migration/sql/r1-validation/04-inventory-validation.sql`
+- `migration/sql/r1-validation/05-report-validation.sql`
+- `migration/sql/r1-validation/06-order-lot-validation.sql`
+- `migration/sql/r1-validation/07-board-validation.sql`
+- `migration/sql/r1-validation/08-quality-doc-validation.sql`
+
+## 3) 결과 요약
+| 항목 | 값 | 판정 |
+|---|---:|---|
+| 실행 도메인 수 | `<8>` | `<PASS/FAIL>` |
+| count mismatch 도메인 수 | `<n>` | `<PASS/FAIL>` |
+| sum 임계치 초과 도메인 수 | `<n>` | `<PASS/FAIL>` |
+| sample mismatch 초과 도메인 수 | `<n>` | `<PASS/FAIL>` |
+| status delta 초과 도메인 수 | `<n>` | `<PASS/FAIL>` |
+| 최종 판정 | `<GO/NO-GO>` | `<확정>` |
+
+## 4) 도메인별 결과
+
+### 4.1 auth
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(failed_count) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(password_algo) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.2 member
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(active_count) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(status) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.3 file
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(DATALENGTH(storage_path)) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(domain_key) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.4 inventory
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count(balances/movements) |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(quantity) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200, movements) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(movement_type) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.5 report
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(failed_count) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(status) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.6 order-lot
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count(orders/lots) |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(order_lots.quantity) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200, lots) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(orders.status) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.7 board
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(notice_count) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(status) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.8 quality-doc
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count(documents/acks) |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(ack_count) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200, documents) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(documents.status) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+## 5) 이슈 / 조치
+| Domain | 이슈 유형(count/sum/sample/status) | 증상 | 원인 | 조치 내용 | 재검증 결과 |
+|---|---|---|---|---|---|
+|  |  |  |  |  |  |
+
+## 6) Go/No-Go 초안
+| 기준 | 결과 | 판정 |
+|---|---|---|
+| count mismatch = 0 |  |  |
+| sum delta <= 0.1% |  |  |
+| sample mismatch = 0/200 |  |  |
+| status delta <= 1.0%p |  |  |
+| 종합 |  | `<GO / NO-GO>` |
+
+## 7) R1 판정 체크 규칙 (고정)
+- `count mismatch = 0` 이 아니면 `NO-GO`.
+- `sum delta > 0.1%` 인 도메인이 1개라도 있으면 `NO-GO`.
+- `sample mismatch > 0/200` 인 도메인이 1개라도 있으면 `NO-GO`.
+- `status delta > 1.0%p` 인 도메인이 1개라도 있으면 `NO-GO`.
+
+## 8) 부록 (실행 로그 / 커맨드)
+```powershell
+# 예시: sqlcmd 실행
+# sqlcmd -S <server> -U <user> -P <password> -i migration/sql/r1-validation/01-auth-validation.sql -o migration/reports/R1-auth-output.txt
+```

--- a/migration/scripts/run-r1-validation.ps1
+++ b/migration/scripts/run-r1-validation.ps1
@@ -1,0 +1,125 @@
+param(
+  [string]$RunId = "",
+  [string]$Server = "localhost,1433",
+  [string]$Database = "master",
+  [string]$User = "sa",
+  [string]$Password = "",
+  [string]$SqlDir = "migration/sql/r1-validation",
+  [string]$ReportDir = "migration/reports",
+  [switch]$UseTrustedConnection,
+  [switch]$SkipSqlExecution
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+
+if ([string]::IsNullOrWhiteSpace($RunId)) {
+  $RunId = "R1-{0}-DEV" -f (Get-Date -Format "yyyyMMdd-HHmmss")
+}
+
+$resolvedSqlDir = if ([System.IO.Path]::IsPathRooted($SqlDir)) { $SqlDir } else { Join-Path $repoRoot $SqlDir }
+$resolvedReportDir = if ([System.IO.Path]::IsPathRooted($ReportDir)) { $ReportDir } else { Join-Path $repoRoot $ReportDir }
+$templatePath = Join-Path $resolvedReportDir "R1-report-template.md"
+
+if (-not (Test-Path $resolvedSqlDir)) {
+  throw "SQL directory not found: $resolvedSqlDir"
+}
+if (-not (Test-Path $templatePath)) {
+  throw "Template not found: $templatePath"
+}
+
+New-Item -ItemType Directory -Force -Path $resolvedReportDir | Out-Null
+
+$domains = @(
+  @{ Key = "auth"; File = "01-auth-validation.sql" },
+  @{ Key = "member"; File = "02-member-validation.sql" },
+  @{ Key = "file"; File = "03-file-validation.sql" },
+  @{ Key = "inventory"; File = "04-inventory-validation.sql" },
+  @{ Key = "report"; File = "05-report-validation.sql" },
+  @{ Key = "order-lot"; File = "06-order-lot-validation.sql" },
+  @{ Key = "board"; File = "07-board-validation.sql" },
+  @{ Key = "quality-doc"; File = "08-quality-doc-validation.sql" }
+)
+
+$outputs = @()
+
+if (-not $SkipSqlExecution) {
+  $sqlcmd = Get-Command sqlcmd -ErrorAction SilentlyContinue
+  if (-not $sqlcmd) {
+    throw "sqlcmd is required. Install SQL Server command line tools or run with -SkipSqlExecution."
+  }
+
+  foreach ($item in $domains) {
+    $sqlPath = Join-Path $resolvedSqlDir $item.File
+    if (-not (Test-Path $sqlPath)) {
+      throw "SQL file not found: $sqlPath"
+    }
+
+    $outPath = Join-Path $resolvedReportDir ("R1-{0}-{1}.out.txt" -f $RunId, $item.Key)
+    $args = @("-S", $Server, "-d", $Database, "-i", $sqlPath, "-o", $outPath, "-b", "-I")
+    if ($UseTrustedConnection) {
+      $args += "-E"
+    }
+    else {
+      if ([string]::IsNullOrWhiteSpace($Password)) {
+        throw "Password is required when -UseTrustedConnection is not set."
+      }
+      $args += @("-U", $User, "-P", $Password)
+    }
+
+    Write-Host ("[INFO] executing: {0}" -f $item.File)
+    & sqlcmd @args
+    if ($LASTEXITCODE -ne 0) {
+      throw ("sqlcmd failed for {0}" -f $item.File)
+    }
+    $outputs += [pscustomobject]@{
+      Domain = $item.Key
+      OutputPath = $outPath
+    }
+  }
+}
+
+$reportFile = Join-Path $resolvedReportDir ("{0}-execution.md" -f $RunId)
+$template = Get-Content -Raw -Encoding UTF8 $templatePath
+$template = $template.Replace("<R1-YYYYMMDD-HHMMSS-ENV>", $RunId)
+$template = $template.Replace("<yyyy-MM-dd HH:mm:ss>", (Get-Date -Format "yyyy-MM-dd HH:mm:ss"))
+$template = $template.Replace("<DEV|STG|PRD-REHEARSAL>", "DEV")
+
+$sb = New-Object System.Text.StringBuilder
+[void]$sb.AppendLine("# SCM-213 R1 Execution Result")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine(("- RunId: {0}" -f $RunId))
+[void]$sb.AppendLine(("- GeneratedAt: {0}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss")))
+[void]$sb.AppendLine(("- SqlDir: {0}" -f $resolvedSqlDir))
+[void]$sb.AppendLine(("- SqlExecution: {0}" -f ($(if ($SkipSqlExecution) { "SKIPPED" } else { "EXECUTED" }))))
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("## Domain Execution Order")
+[void]$sb.AppendLine("auth -> member -> file -> inventory -> report -> order-lot -> board -> quality-doc")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("## Raw Outputs")
+[void]$sb.AppendLine("| Domain | Output File |")
+[void]$sb.AppendLine("|---|---|")
+if ($outputs.Count -eq 0) {
+  foreach ($item in $domains) {
+    [void]$sb.AppendLine(("| {0} | PENDING ({1}-{0}.out.txt) |" -f $item.Key, $RunId))
+  }
+}
+else {
+  foreach ($out in $outputs) {
+    $relative = $out.OutputPath.Replace($repoRoot + "\", "")
+    [void]$sb.AppendLine(("| {0} | {1} |" -f $out.Domain, $relative))
+  }
+}
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("## R1 Thresholds")
+[void]$sb.AppendLine("- count mismatch = 0")
+[void]$sb.AppendLine("- sum delta <= 0.1%")
+[void]$sb.AppendLine("- sample mismatch = 0/200")
+[void]$sb.AppendLine("- status delta <= 1.0%p")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("## Template Appendix")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine($template)
+
+$sb.ToString() | Set-Content -Encoding UTF8 $reportFile
+Write-Host ("[OK] R1 execution report created: {0}" -f $reportFile)

--- a/migration/sql/r1-validation/01-auth-validation.sql
+++ b/migration/sql/r1-validation/01-auth-validation.sql
@@ -1,0 +1,183 @@
+﻿/*
+  SCM-213 R1 Domain Validation SQL
+  Domain: auth
+  목적: legacy vs target 비교 (count / sum / sample200 / status distribution)
+
+  기본 DB:
+    - Legacy : [MES_HI_LEGACY]
+    - Target : [MES_HI]
+
+  TODO:
+    - legacy DB명이 다르면 [MES_HI_LEGACY]를 실제 DB명으로 변경.
+    - legacy auth 테이블/컬럼이 다르면 legacy_base CTE만 수정.
+*/
+
+SET NOCOUNT ON;
+DECLARE @Domain NVARCHAR(30) = N'auth';
+DECLARE @SampleSize INT = 200;
+
+/* 1) count 비교 (양쪽) */
+WITH legacy_base AS (
+    SELECT login_id, member_id, password_algo, failed_count, updated_at
+    FROM [MES_HI_LEGACY].dbo.auth_credentials
+),
+target_base AS (
+    SELECT login_id, member_id, password_algo, failed_count, updated_at
+    FROM [MES_HI].dbo.auth_credentials
+),
+legacy_count AS (
+    SELECT COUNT_BIG(1) AS cnt FROM legacy_base
+),
+target_count AS (
+    SELECT COUNT_BIG(1) AS cnt FROM target_base
+)
+SELECT
+    @Domain AS domain,
+    lc.cnt AS legacy_count,
+    tc.cnt AS target_count,
+    ABS(tc.cnt - lc.cnt) AS count_mismatch
+FROM legacy_count lc
+CROSS JOIN target_count tc;
+
+/* 2) sum 비교 (failed_count) + 편차 계산 */
+WITH legacy_base AS (
+    SELECT ISNULL(failed_count, 0) AS failed_count
+    FROM [MES_HI_LEGACY].dbo.auth_credentials
+),
+target_base AS (
+    SELECT ISNULL(failed_count, 0) AS failed_count
+    FROM [MES_HI].dbo.auth_credentials
+),
+legacy_sum AS (
+    SELECT CAST(SUM(CAST(failed_count AS DECIMAL(38, 6))) AS DECIMAL(38, 6)) AS sum_value FROM legacy_base
+),
+target_sum AS (
+    SELECT CAST(SUM(CAST(failed_count AS DECIMAL(38, 6))) AS DECIMAL(38, 6)) AS sum_value FROM target_base
+)
+SELECT
+    @Domain AS domain,
+    ls.sum_value AS legacy_sum,
+    ts.sum_value AS target_sum,
+    CAST(ABS(ts.sum_value - ls.sum_value) AS DECIMAL(38, 6)) AS abs_delta,
+    CAST(
+        CASE
+            WHEN ls.sum_value = 0 AND ts.sum_value = 0 THEN 0
+            WHEN ls.sum_value = 0 THEN 100.0
+            ELSE ABS(ts.sum_value - ls.sum_value) * 100.0 / ABS(ls.sum_value)
+        END
+        AS DECIMAL(18, 6)
+    ) AS delta_pct
+FROM legacy_sum ls
+CROSS JOIN target_sum ts;
+
+/* 3) sample 200 비교를 위한 키 추출 (양쪽) + mismatch 계산 */
+WITH legacy_base AS (
+    SELECT
+        login_id AS sample_key,
+        CHECKSUM(login_id, member_id, password_algo, ISNULL(failed_count, 0)) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.auth_credentials
+),
+target_base AS (
+    SELECT
+        login_id AS sample_key,
+        CHECKSUM(login_id, member_id, password_algo, ISNULL(failed_count, 0)) AS row_hash
+    FROM [MES_HI].dbo.auth_credentials
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+)
+SELECT
+    COALESCE(l.sample_key, t.sample_key) AS sample_key,
+    l.row_hash AS legacy_hash,
+    t.row_hash AS target_hash,
+    CASE WHEN l.row_hash = t.row_hash AND l.sample_key IS NOT NULL AND t.sample_key IS NOT NULL THEN 0 ELSE 1 END AS is_mismatch
+FROM legacy_sample l
+FULL OUTER JOIN target_sample t
+    ON l.sample_key = t.sample_key
+ORDER BY sample_key;
+
+WITH legacy_base AS (
+    SELECT
+        login_id AS sample_key,
+        CHECKSUM(login_id, member_id, password_algo, ISNULL(failed_count, 0)) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.auth_credentials
+),
+target_base AS (
+    SELECT
+        login_id AS sample_key,
+        CHECKSUM(login_id, member_id, password_algo, ISNULL(failed_count, 0)) AS row_hash
+    FROM [MES_HI].dbo.auth_credentials
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+),
+merged AS (
+    SELECT
+        COALESCE(l.sample_key, t.sample_key) AS sample_key,
+        l.row_hash AS legacy_hash,
+        t.row_hash AS target_hash
+    FROM legacy_sample l
+    FULL OUTER JOIN target_sample t
+        ON l.sample_key = t.sample_key
+)
+SELECT
+    @Domain AS domain,
+    @SampleSize AS sample_size,
+    SUM(CASE WHEN legacy_hash = target_hash AND legacy_hash IS NOT NULL AND target_hash IS NOT NULL THEN 0 ELSE 1 END) AS sample_mismatch_count
+FROM merged;
+
+/* 4) status 분포 비교 (password_algo) + 편차(%p) */
+WITH legacy_dist AS (
+    SELECT password_algo AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI_LEGACY].dbo.auth_credentials
+    GROUP BY password_algo
+),
+target_dist AS (
+    SELECT password_algo AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI].dbo.auth_credentials
+    GROUP BY password_algo
+),
+legacy_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM legacy_dist
+),
+target_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM target_dist
+),
+merged AS (
+    SELECT
+        COALESCE(l.status_key, t.status_key) AS status_key,
+        ISNULL(l.cnt, 0) AS legacy_cnt,
+        ISNULL(t.cnt, 0) AS target_cnt
+    FROM legacy_dist l
+    FULL OUTER JOIN target_dist t
+        ON l.status_key = t.status_key
+)
+SELECT
+    @Domain AS domain,
+    status_key,
+    legacy_cnt,
+    target_cnt,
+    CAST(CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END AS DECIMAL(18, 6)) AS legacy_pct,
+    CAST(CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END AS DECIMAL(18, 6)) AS target_pct,
+    CAST(ABS(
+        (CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END)
+      - (CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END)
+    ) AS DECIMAL(18, 6)) AS delta_pct_point
+FROM merged
+CROSS JOIN legacy_total lt
+CROSS JOIN target_total tt
+ORDER BY status_key;

--- a/migration/sql/r1-validation/02-member-validation.sql
+++ b/migration/sql/r1-validation/02-member-validation.sql
@@ -1,0 +1,183 @@
+﻿/*
+  SCM-213 R1 Domain Validation SQL
+  Domain: member
+  목적: legacy vs target 비교 (count / sum / sample200 / status distribution)
+
+  기본 DB:
+    - Legacy : [MES_HI_LEGACY]
+    - Target : [MES_HI]
+
+  TODO:
+    - legacy DB명이 다르면 [MES_HI_LEGACY]를 실제 DB명으로 변경.
+    - legacy members 컬럼명이 다르면 legacy_base CTE만 수정.
+*/
+
+SET NOCOUNT ON;
+DECLARE @Domain NVARCHAR(30) = N'member';
+DECLARE @SampleSize INT = 200;
+
+/* 1) count 비교 (양쪽) */
+WITH legacy_base AS (
+    SELECT member_id, member_name, status, updated_at
+    FROM [MES_HI_LEGACY].dbo.members
+),
+target_base AS (
+    SELECT member_id, member_name, status, updated_at
+    FROM [MES_HI].dbo.members
+),
+legacy_count AS (
+    SELECT COUNT_BIG(1) AS cnt FROM legacy_base
+),
+target_count AS (
+    SELECT COUNT_BIG(1) AS cnt FROM target_base
+)
+SELECT
+    @Domain AS domain,
+    lc.cnt AS legacy_count,
+    tc.cnt AS target_count,
+    ABS(tc.cnt - lc.cnt) AS count_mismatch
+FROM legacy_count lc
+CROSS JOIN target_count tc;
+
+/* 2) sum 비교 (ACTIVE count) + 편차 계산 */
+WITH legacy_base AS (
+    SELECT CASE WHEN status = N'ACTIVE' THEN 1 ELSE 0 END AS active_flag
+    FROM [MES_HI_LEGACY].dbo.members
+),
+target_base AS (
+    SELECT CASE WHEN status = N'ACTIVE' THEN 1 ELSE 0 END AS active_flag
+    FROM [MES_HI].dbo.members
+),
+legacy_sum AS (
+    SELECT CAST(SUM(CAST(active_flag AS DECIMAL(38, 6))) AS DECIMAL(38, 6)) AS sum_value FROM legacy_base
+),
+target_sum AS (
+    SELECT CAST(SUM(CAST(active_flag AS DECIMAL(38, 6))) AS DECIMAL(38, 6)) AS sum_value FROM target_base
+)
+SELECT
+    @Domain AS domain,
+    ls.sum_value AS legacy_sum,
+    ts.sum_value AS target_sum,
+    CAST(ABS(ts.sum_value - ls.sum_value) AS DECIMAL(38, 6)) AS abs_delta,
+    CAST(
+        CASE
+            WHEN ls.sum_value = 0 AND ts.sum_value = 0 THEN 0
+            WHEN ls.sum_value = 0 THEN 100.0
+            ELSE ABS(ts.sum_value - ls.sum_value) * 100.0 / ABS(ls.sum_value)
+        END
+        AS DECIMAL(18, 6)
+    ) AS delta_pct
+FROM legacy_sum ls
+CROSS JOIN target_sum ts;
+
+/* 3) sample 200 비교를 위한 키 추출 (양쪽) + mismatch 계산 */
+WITH legacy_base AS (
+    SELECT
+        member_id AS sample_key,
+        CHECKSUM(member_id, member_name, status) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.members
+),
+target_base AS (
+    SELECT
+        member_id AS sample_key,
+        CHECKSUM(member_id, member_name, status) AS row_hash
+    FROM [MES_HI].dbo.members
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+)
+SELECT
+    COALESCE(l.sample_key, t.sample_key) AS sample_key,
+    l.row_hash AS legacy_hash,
+    t.row_hash AS target_hash,
+    CASE WHEN l.row_hash = t.row_hash AND l.sample_key IS NOT NULL AND t.sample_key IS NOT NULL THEN 0 ELSE 1 END AS is_mismatch
+FROM legacy_sample l
+FULL OUTER JOIN target_sample t
+    ON l.sample_key = t.sample_key
+ORDER BY sample_key;
+
+WITH legacy_base AS (
+    SELECT
+        member_id AS sample_key,
+        CHECKSUM(member_id, member_name, status) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.members
+),
+target_base AS (
+    SELECT
+        member_id AS sample_key,
+        CHECKSUM(member_id, member_name, status) AS row_hash
+    FROM [MES_HI].dbo.members
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+),
+merged AS (
+    SELECT
+        COALESCE(l.sample_key, t.sample_key) AS sample_key,
+        l.row_hash AS legacy_hash,
+        t.row_hash AS target_hash
+    FROM legacy_sample l
+    FULL OUTER JOIN target_sample t
+        ON l.sample_key = t.sample_key
+)
+SELECT
+    @Domain AS domain,
+    @SampleSize AS sample_size,
+    SUM(CASE WHEN legacy_hash = target_hash AND legacy_hash IS NOT NULL AND target_hash IS NOT NULL THEN 0 ELSE 1 END) AS sample_mismatch_count
+FROM merged;
+
+/* 4) status 분포 비교 (status) + 편차(%p) */
+WITH legacy_dist AS (
+    SELECT status AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI_LEGACY].dbo.members
+    GROUP BY status
+),
+target_dist AS (
+    SELECT status AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI].dbo.members
+    GROUP BY status
+),
+legacy_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM legacy_dist
+),
+target_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM target_dist
+),
+merged AS (
+    SELECT
+        COALESCE(l.status_key, t.status_key) AS status_key,
+        ISNULL(l.cnt, 0) AS legacy_cnt,
+        ISNULL(t.cnt, 0) AS target_cnt
+    FROM legacy_dist l
+    FULL OUTER JOIN target_dist t
+        ON l.status_key = t.status_key
+)
+SELECT
+    @Domain AS domain,
+    status_key,
+    legacy_cnt,
+    target_cnt,
+    CAST(CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END AS DECIMAL(18, 6)) AS legacy_pct,
+    CAST(CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END AS DECIMAL(18, 6)) AS target_pct,
+    CAST(ABS(
+        (CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END)
+      - (CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END)
+    ) AS DECIMAL(18, 6)) AS delta_pct_point
+FROM merged
+CROSS JOIN legacy_total lt
+CROSS JOIN target_total tt
+ORDER BY status_key;

--- a/migration/sql/r1-validation/03-file-validation.sql
+++ b/migration/sql/r1-validation/03-file-validation.sql
@@ -1,0 +1,183 @@
+﻿/*
+  SCM-213 R1 Domain Validation SQL
+  Domain: file
+  목적: legacy vs target 비교 (count / sum / sample200 / status distribution)
+
+  기본 DB:
+    - Legacy : [MES_HI_LEGACY]
+    - Target : [MES_HI]
+
+  TODO:
+    - legacy DB명이 다르면 [MES_HI_LEGACY]를 실제 DB명으로 변경.
+    - legacy upload_files 컬럼명이 다르면 legacy_base CTE만 수정.
+*/
+
+SET NOCOUNT ON;
+DECLARE @Domain NVARCHAR(30) = N'file';
+DECLARE @SampleSize INT = 200;
+
+/* 1) count 비교 (양쪽) */
+WITH legacy_base AS (
+    SELECT file_id, domain_key, storage_path, original_name, created_at
+    FROM [MES_HI_LEGACY].dbo.upload_files
+),
+target_base AS (
+    SELECT file_id, domain_key, storage_path, original_name, created_at
+    FROM [MES_HI].dbo.upload_files
+),
+legacy_count AS (
+    SELECT COUNT_BIG(1) AS cnt FROM legacy_base
+),
+target_count AS (
+    SELECT COUNT_BIG(1) AS cnt FROM target_base
+)
+SELECT
+    @Domain AS domain,
+    lc.cnt AS legacy_count,
+    tc.cnt AS target_count,
+    ABS(tc.cnt - lc.cnt) AS count_mismatch
+FROM legacy_count lc
+CROSS JOIN target_count tc;
+
+/* 2) sum 비교 (DATALENGTH(storage_path)) + 편차 계산 */
+WITH legacy_base AS (
+    SELECT CAST(ISNULL(DATALENGTH(storage_path), 0) AS DECIMAL(38, 6)) AS metric_value
+    FROM [MES_HI_LEGACY].dbo.upload_files
+),
+target_base AS (
+    SELECT CAST(ISNULL(DATALENGTH(storage_path), 0) AS DECIMAL(38, 6)) AS metric_value
+    FROM [MES_HI].dbo.upload_files
+),
+legacy_sum AS (
+    SELECT CAST(SUM(metric_value) AS DECIMAL(38, 6)) AS sum_value FROM legacy_base
+),
+target_sum AS (
+    SELECT CAST(SUM(metric_value) AS DECIMAL(38, 6)) AS sum_value FROM target_base
+)
+SELECT
+    @Domain AS domain,
+    ls.sum_value AS legacy_sum,
+    ts.sum_value AS target_sum,
+    CAST(ABS(ts.sum_value - ls.sum_value) AS DECIMAL(38, 6)) AS abs_delta,
+    CAST(
+        CASE
+            WHEN ls.sum_value = 0 AND ts.sum_value = 0 THEN 0
+            WHEN ls.sum_value = 0 THEN 100.0
+            ELSE ABS(ts.sum_value - ls.sum_value) * 100.0 / ABS(ls.sum_value)
+        END
+        AS DECIMAL(18, 6)
+    ) AS delta_pct
+FROM legacy_sum ls
+CROSS JOIN target_sum ts;
+
+/* 3) sample 200 비교를 위한 키 추출 (양쪽) + mismatch 계산 */
+WITH legacy_base AS (
+    SELECT
+        CAST(file_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(file_id AS NVARCHAR(64)), domain_key, storage_path, original_name) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.upload_files
+),
+target_base AS (
+    SELECT
+        CAST(file_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(file_id AS NVARCHAR(64)), domain_key, storage_path, original_name) AS row_hash
+    FROM [MES_HI].dbo.upload_files
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+)
+SELECT
+    COALESCE(l.sample_key, t.sample_key) AS sample_key,
+    l.row_hash AS legacy_hash,
+    t.row_hash AS target_hash,
+    CASE WHEN l.row_hash = t.row_hash AND l.sample_key IS NOT NULL AND t.sample_key IS NOT NULL THEN 0 ELSE 1 END AS is_mismatch
+FROM legacy_sample l
+FULL OUTER JOIN target_sample t
+    ON l.sample_key = t.sample_key
+ORDER BY sample_key;
+
+WITH legacy_base AS (
+    SELECT
+        CAST(file_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(file_id AS NVARCHAR(64)), domain_key, storage_path, original_name) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.upload_files
+),
+target_base AS (
+    SELECT
+        CAST(file_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(file_id AS NVARCHAR(64)), domain_key, storage_path, original_name) AS row_hash
+    FROM [MES_HI].dbo.upload_files
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+),
+merged AS (
+    SELECT
+        COALESCE(l.sample_key, t.sample_key) AS sample_key,
+        l.row_hash AS legacy_hash,
+        t.row_hash AS target_hash
+    FROM legacy_sample l
+    FULL OUTER JOIN target_sample t
+        ON l.sample_key = t.sample_key
+)
+SELECT
+    @Domain AS domain,
+    @SampleSize AS sample_size,
+    SUM(CASE WHEN legacy_hash = target_hash AND legacy_hash IS NOT NULL AND target_hash IS NOT NULL THEN 0 ELSE 1 END) AS sample_mismatch_count
+FROM merged;
+
+/* 4) status 분포 비교 (domain_key) + 편차(%p) */
+WITH legacy_dist AS (
+    SELECT domain_key AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI_LEGACY].dbo.upload_files
+    GROUP BY domain_key
+),
+target_dist AS (
+    SELECT domain_key AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI].dbo.upload_files
+    GROUP BY domain_key
+),
+legacy_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM legacy_dist
+),
+target_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM target_dist
+),
+merged AS (
+    SELECT
+        COALESCE(l.status_key, t.status_key) AS status_key,
+        ISNULL(l.cnt, 0) AS legacy_cnt,
+        ISNULL(t.cnt, 0) AS target_cnt
+    FROM legacy_dist l
+    FULL OUTER JOIN target_dist t
+        ON l.status_key = t.status_key
+)
+SELECT
+    @Domain AS domain,
+    status_key,
+    legacy_cnt,
+    target_cnt,
+    CAST(CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END AS DECIMAL(18, 6)) AS legacy_pct,
+    CAST(CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END AS DECIMAL(18, 6)) AS target_pct,
+    CAST(ABS(
+        (CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END)
+      - (CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END)
+    ) AS DECIMAL(18, 6)) AS delta_pct_point
+FROM merged
+CROSS JOIN legacy_total lt
+CROSS JOIN target_total tt
+ORDER BY status_key;

--- a/migration/sql/r1-validation/04-inventory-validation.sql
+++ b/migration/sql/r1-validation/04-inventory-validation.sql
@@ -1,0 +1,204 @@
+﻿/*
+  SCM-213 R1 Domain Validation SQL
+  Domain: inventory
+  목적: legacy vs target 비교 (count / sum / sample200 / status distribution)
+
+  기본 DB:
+    - Legacy : [MES_HI_LEGACY]
+    - Target : [MES_HI]
+
+  TODO:
+    - legacy DB명이 다르면 [MES_HI_LEGACY]를 실제 DB명으로 변경.
+    - legacy inventory_balances / inventory_movements 컬럼명이 다르면 legacy CTE만 수정.
+*/
+
+SET NOCOUNT ON;
+DECLARE @Domain NVARCHAR(30) = N'inventory';
+DECLARE @SampleSize INT = 200;
+
+/* 1) count 비교 (balances + movements) */
+WITH legacy_bal AS (
+    SELECT item_code, warehouse_code, quantity, updated_at
+    FROM [MES_HI_LEGACY].dbo.inventory_balances
+),
+target_bal AS (
+    SELECT item_code, warehouse_code, quantity, updated_at
+    FROM [MES_HI].dbo.inventory_balances
+),
+legacy_mov AS (
+    SELECT movement_id, item_code, warehouse_code, movement_type, quantity, moved_at
+    FROM [MES_HI_LEGACY].dbo.inventory_movements
+),
+target_mov AS (
+    SELECT movement_id, item_code, warehouse_code, movement_type, quantity, moved_at
+    FROM [MES_HI].dbo.inventory_movements
+)
+SELECT
+    @Domain AS domain,
+    N'inventory_balances' AS metric,
+    (SELECT COUNT_BIG(1) FROM legacy_bal) AS legacy_count,
+    (SELECT COUNT_BIG(1) FROM target_bal) AS target_count,
+    ABS((SELECT COUNT_BIG(1) FROM target_bal) - (SELECT COUNT_BIG(1) FROM legacy_bal)) AS count_mismatch
+UNION ALL
+SELECT
+    @Domain AS domain,
+    N'inventory_movements' AS metric,
+    (SELECT COUNT_BIG(1) FROM legacy_mov) AS legacy_count,
+    (SELECT COUNT_BIG(1) FROM target_mov) AS target_count,
+    ABS((SELECT COUNT_BIG(1) FROM target_mov) - (SELECT COUNT_BIG(1) FROM legacy_mov)) AS count_mismatch;
+
+/* 2) sum 비교 (quantity) + 편차 계산 */
+WITH legacy_bal AS (
+    SELECT CAST(ISNULL(quantity, 0) AS DECIMAL(38, 6)) AS qty
+    FROM [MES_HI_LEGACY].dbo.inventory_balances
+),
+target_bal AS (
+    SELECT CAST(ISNULL(quantity, 0) AS DECIMAL(38, 6)) AS qty
+    FROM [MES_HI].dbo.inventory_balances
+),
+legacy_mov AS (
+    SELECT CAST(ISNULL(quantity, 0) AS DECIMAL(38, 6)) AS qty
+    FROM [MES_HI_LEGACY].dbo.inventory_movements
+),
+target_mov AS (
+    SELECT CAST(ISNULL(quantity, 0) AS DECIMAL(38, 6)) AS qty
+    FROM [MES_HI].dbo.inventory_movements
+),
+metrics AS (
+    SELECT
+        N'balance_quantity_sum' AS metric,
+        (SELECT CAST(SUM(qty) AS DECIMAL(38, 6)) FROM legacy_bal) AS legacy_sum,
+        (SELECT CAST(SUM(qty) AS DECIMAL(38, 6)) FROM target_bal) AS target_sum
+    UNION ALL
+    SELECT
+        N'movement_quantity_sum' AS metric,
+        (SELECT CAST(SUM(qty) AS DECIMAL(38, 6)) FROM legacy_mov) AS legacy_sum,
+        (SELECT CAST(SUM(qty) AS DECIMAL(38, 6)) FROM target_mov) AS target_sum
+)
+SELECT
+    @Domain AS domain,
+    metric,
+    legacy_sum,
+    target_sum,
+    CAST(ABS(target_sum - legacy_sum) AS DECIMAL(38, 6)) AS abs_delta,
+    CAST(
+        CASE
+            WHEN legacy_sum = 0 AND target_sum = 0 THEN 0
+            WHEN legacy_sum = 0 THEN 100.0
+            ELSE ABS(target_sum - legacy_sum) * 100.0 / ABS(legacy_sum)
+        END
+        AS DECIMAL(18, 6)
+    ) AS delta_pct
+FROM metrics;
+
+/* 3) sample 200 비교를 위한 키 추출 (movements 양쪽) + mismatch 계산 */
+WITH legacy_base AS (
+    SELECT
+        CAST(movement_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(movement_id AS NVARCHAR(64)), item_code, warehouse_code, movement_type, quantity, moved_at) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.inventory_movements
+),
+target_base AS (
+    SELECT
+        CAST(movement_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(movement_id AS NVARCHAR(64)), item_code, warehouse_code, movement_type, quantity, moved_at) AS row_hash
+    FROM [MES_HI].dbo.inventory_movements
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+)
+SELECT
+    COALESCE(l.sample_key, t.sample_key) AS sample_key,
+    l.row_hash AS legacy_hash,
+    t.row_hash AS target_hash,
+    CASE WHEN l.row_hash = t.row_hash AND l.sample_key IS NOT NULL AND t.sample_key IS NOT NULL THEN 0 ELSE 1 END AS is_mismatch
+FROM legacy_sample l
+FULL OUTER JOIN target_sample t
+    ON l.sample_key = t.sample_key
+ORDER BY sample_key;
+
+WITH legacy_base AS (
+    SELECT
+        CAST(movement_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(movement_id AS NVARCHAR(64)), item_code, warehouse_code, movement_type, quantity, moved_at) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.inventory_movements
+),
+target_base AS (
+    SELECT
+        CAST(movement_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(movement_id AS NVARCHAR(64)), item_code, warehouse_code, movement_type, quantity, moved_at) AS row_hash
+    FROM [MES_HI].dbo.inventory_movements
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+),
+merged AS (
+    SELECT
+        COALESCE(l.sample_key, t.sample_key) AS sample_key,
+        l.row_hash AS legacy_hash,
+        t.row_hash AS target_hash
+    FROM legacy_sample l
+    FULL OUTER JOIN target_sample t
+        ON l.sample_key = t.sample_key
+)
+SELECT
+    @Domain AS domain,
+    @SampleSize AS sample_size,
+    SUM(CASE WHEN legacy_hash = target_hash AND legacy_hash IS NOT NULL AND target_hash IS NOT NULL THEN 0 ELSE 1 END) AS sample_mismatch_count
+FROM merged;
+
+/* 4) status 분포 비교 (movement_type) + 편차(%p) */
+WITH legacy_dist AS (
+    SELECT movement_type AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI_LEGACY].dbo.inventory_movements
+    GROUP BY movement_type
+),
+target_dist AS (
+    SELECT movement_type AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI].dbo.inventory_movements
+    GROUP BY movement_type
+),
+legacy_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM legacy_dist
+),
+target_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM target_dist
+),
+merged AS (
+    SELECT
+        COALESCE(l.status_key, t.status_key) AS status_key,
+        ISNULL(l.cnt, 0) AS legacy_cnt,
+        ISNULL(t.cnt, 0) AS target_cnt
+    FROM legacy_dist l
+    FULL OUTER JOIN target_dist t
+        ON l.status_key = t.status_key
+)
+SELECT
+    @Domain AS domain,
+    status_key,
+    legacy_cnt,
+    target_cnt,
+    CAST(CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END AS DECIMAL(18, 6)) AS legacy_pct,
+    CAST(CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END AS DECIMAL(18, 6)) AS target_pct,
+    CAST(ABS(
+        (CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END)
+      - (CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END)
+    ) AS DECIMAL(18, 6)) AS delta_pct_point
+FROM merged
+CROSS JOIN legacy_total lt
+CROSS JOIN target_total tt
+ORDER BY status_key;

--- a/migration/sql/r1-validation/05-report-validation.sql
+++ b/migration/sql/r1-validation/05-report-validation.sql
@@ -1,0 +1,183 @@
+﻿/*
+  SCM-213 R1 Domain Validation SQL
+  Domain: report
+  목적: legacy vs target 비교 (count / sum / sample200 / status distribution)
+
+  기본 DB:
+    - Legacy : [MES_HI_LEGACY]
+    - Target : [MES_HI]
+
+  TODO:
+    - legacy DB명이 다르면 [MES_HI_LEGACY]를 실제 DB명으로 변경.
+    - legacy report_jobs 컬럼명이 다르면 legacy_base CTE만 수정.
+*/
+
+SET NOCOUNT ON;
+DECLARE @Domain NVARCHAR(30) = N'report';
+DECLARE @SampleSize INT = 200;
+
+/* 1) count 비교 (양쪽) */
+WITH legacy_base AS (
+    SELECT job_id, report_type, requested_by_member_id, status, requested_at, completed_at, output_file_id
+    FROM [MES_HI_LEGACY].dbo.report_jobs
+),
+target_base AS (
+    SELECT job_id, report_type, requested_by_member_id, status, requested_at, completed_at, output_file_id
+    FROM [MES_HI].dbo.report_jobs
+),
+legacy_count AS (
+    SELECT COUNT_BIG(1) AS cnt FROM legacy_base
+),
+target_count AS (
+    SELECT COUNT_BIG(1) AS cnt FROM target_base
+)
+SELECT
+    @Domain AS domain,
+    lc.cnt AS legacy_count,
+    tc.cnt AS target_count,
+    ABS(tc.cnt - lc.cnt) AS count_mismatch
+FROM legacy_count lc
+CROSS JOIN target_count tc;
+
+/* 2) sum 비교 (FAILED count) + 편차 계산 */
+WITH legacy_base AS (
+    SELECT CASE WHEN status = N'FAILED' THEN 1 ELSE 0 END AS failed_flag
+    FROM [MES_HI_LEGACY].dbo.report_jobs
+),
+target_base AS (
+    SELECT CASE WHEN status = N'FAILED' THEN 1 ELSE 0 END AS failed_flag
+    FROM [MES_HI].dbo.report_jobs
+),
+legacy_sum AS (
+    SELECT CAST(SUM(CAST(failed_flag AS DECIMAL(38, 6))) AS DECIMAL(38, 6)) AS sum_value FROM legacy_base
+),
+target_sum AS (
+    SELECT CAST(SUM(CAST(failed_flag AS DECIMAL(38, 6))) AS DECIMAL(38, 6)) AS sum_value FROM target_base
+)
+SELECT
+    @Domain AS domain,
+    ls.sum_value AS legacy_sum,
+    ts.sum_value AS target_sum,
+    CAST(ABS(ts.sum_value - ls.sum_value) AS DECIMAL(38, 6)) AS abs_delta,
+    CAST(
+        CASE
+            WHEN ls.sum_value = 0 AND ts.sum_value = 0 THEN 0
+            WHEN ls.sum_value = 0 THEN 100.0
+            ELSE ABS(ts.sum_value - ls.sum_value) * 100.0 / ABS(ls.sum_value)
+        END
+        AS DECIMAL(18, 6)
+    ) AS delta_pct
+FROM legacy_sum ls
+CROSS JOIN target_sum ts;
+
+/* 3) sample 200 비교를 위한 키 추출 (양쪽) + mismatch 계산 */
+WITH legacy_base AS (
+    SELECT
+        CAST(job_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(job_id AS NVARCHAR(64)), report_type, status, requested_at, completed_at) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.report_jobs
+),
+target_base AS (
+    SELECT
+        CAST(job_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(job_id AS NVARCHAR(64)), report_type, status, requested_at, completed_at) AS row_hash
+    FROM [MES_HI].dbo.report_jobs
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+)
+SELECT
+    COALESCE(l.sample_key, t.sample_key) AS sample_key,
+    l.row_hash AS legacy_hash,
+    t.row_hash AS target_hash,
+    CASE WHEN l.row_hash = t.row_hash AND l.sample_key IS NOT NULL AND t.sample_key IS NOT NULL THEN 0 ELSE 1 END AS is_mismatch
+FROM legacy_sample l
+FULL OUTER JOIN target_sample t
+    ON l.sample_key = t.sample_key
+ORDER BY sample_key;
+
+WITH legacy_base AS (
+    SELECT
+        CAST(job_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(job_id AS NVARCHAR(64)), report_type, status, requested_at, completed_at) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.report_jobs
+),
+target_base AS (
+    SELECT
+        CAST(job_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(job_id AS NVARCHAR(64)), report_type, status, requested_at, completed_at) AS row_hash
+    FROM [MES_HI].dbo.report_jobs
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+),
+merged AS (
+    SELECT
+        COALESCE(l.sample_key, t.sample_key) AS sample_key,
+        l.row_hash AS legacy_hash,
+        t.row_hash AS target_hash
+    FROM legacy_sample l
+    FULL OUTER JOIN target_sample t
+        ON l.sample_key = t.sample_key
+)
+SELECT
+    @Domain AS domain,
+    @SampleSize AS sample_size,
+    SUM(CASE WHEN legacy_hash = target_hash AND legacy_hash IS NOT NULL AND target_hash IS NOT NULL THEN 0 ELSE 1 END) AS sample_mismatch_count
+FROM merged;
+
+/* 4) status 분포 비교 (status) + 편차(%p) */
+WITH legacy_dist AS (
+    SELECT status AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI_LEGACY].dbo.report_jobs
+    GROUP BY status
+),
+target_dist AS (
+    SELECT status AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI].dbo.report_jobs
+    GROUP BY status
+),
+legacy_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM legacy_dist
+),
+target_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM target_dist
+),
+merged AS (
+    SELECT
+        COALESCE(l.status_key, t.status_key) AS status_key,
+        ISNULL(l.cnt, 0) AS legacy_cnt,
+        ISNULL(t.cnt, 0) AS target_cnt
+    FROM legacy_dist l
+    FULL OUTER JOIN target_dist t
+        ON l.status_key = t.status_key
+)
+SELECT
+    @Domain AS domain,
+    status_key,
+    legacy_cnt,
+    target_cnt,
+    CAST(CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END AS DECIMAL(18, 6)) AS legacy_pct,
+    CAST(CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END AS DECIMAL(18, 6)) AS target_pct,
+    CAST(ABS(
+        (CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END)
+      - (CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END)
+    ) AS DECIMAL(18, 6)) AS delta_pct_point
+FROM merged
+CROSS JOIN legacy_total lt
+CROSS JOIN target_total tt
+ORDER BY status_key;

--- a/migration/sql/r1-validation/06-order-lot-validation.sql
+++ b/migration/sql/r1-validation/06-order-lot-validation.sql
@@ -1,0 +1,192 @@
+﻿/*
+  SCM-213 R1 Domain Validation SQL
+  Domain: order-lot
+  목적: legacy vs target 비교 (count / sum / sample200 / status distribution)
+
+  기본 DB:
+    - Legacy : [MES_HI_LEGACY]
+    - Target : [MES_HI]
+
+  TODO:
+    - legacy DB명이 다르면 [MES_HI_LEGACY]를 실제 DB명으로 변경.
+    - legacy orders/order_lots 키가 다르면 legacy CTE만 수정.
+      (현재 가정: orders.order_no, order_lots.lot_no/order_no)
+*/
+
+SET NOCOUNT ON;
+DECLARE @Domain NVARCHAR(30) = N'order-lot';
+DECLARE @SampleSize INT = 200;
+
+/* 1) count 비교 (orders + order_lots) */
+WITH legacy_orders AS (
+    SELECT order_no, member_id, order_date, status, created_at
+    FROM [MES_HI_LEGACY].dbo.orders
+),
+target_orders AS (
+    SELECT order_no, member_id, order_date, status, created_at
+    FROM [MES_HI].dbo.orders
+),
+legacy_lots AS (
+    SELECT lot_no, order_no, quantity, status, created_at
+    FROM [MES_HI_LEGACY].dbo.order_lots
+),
+target_lots AS (
+    SELECT lot_no, order_no, quantity, status, created_at
+    FROM [MES_HI].dbo.order_lots
+)
+SELECT
+    @Domain AS domain,
+    N'orders' AS metric,
+    (SELECT COUNT_BIG(1) FROM legacy_orders) AS legacy_count,
+    (SELECT COUNT_BIG(1) FROM target_orders) AS target_count,
+    ABS((SELECT COUNT_BIG(1) FROM target_orders) - (SELECT COUNT_BIG(1) FROM legacy_orders)) AS count_mismatch
+UNION ALL
+SELECT
+    @Domain AS domain,
+    N'order_lots' AS metric,
+    (SELECT COUNT_BIG(1) FROM legacy_lots) AS legacy_count,
+    (SELECT COUNT_BIG(1) FROM target_lots) AS target_count,
+    ABS((SELECT COUNT_BIG(1) FROM target_lots) - (SELECT COUNT_BIG(1) FROM legacy_lots)) AS count_mismatch;
+
+/* 2) sum 비교 (order_lots.quantity) + 편차 계산 */
+WITH legacy_lots AS (
+    SELECT CAST(ISNULL(quantity, 0) AS DECIMAL(38, 6)) AS qty
+    FROM [MES_HI_LEGACY].dbo.order_lots
+),
+target_lots AS (
+    SELECT CAST(ISNULL(quantity, 0) AS DECIMAL(38, 6)) AS qty
+    FROM [MES_HI].dbo.order_lots
+),
+legacy_sum AS (
+    SELECT CAST(SUM(qty) AS DECIMAL(38, 6)) AS sum_value FROM legacy_lots
+),
+target_sum AS (
+    SELECT CAST(SUM(qty) AS DECIMAL(38, 6)) AS sum_value FROM target_lots
+)
+SELECT
+    @Domain AS domain,
+    ls.sum_value AS legacy_sum,
+    ts.sum_value AS target_sum,
+    CAST(ABS(ts.sum_value - ls.sum_value) AS DECIMAL(38, 6)) AS abs_delta,
+    CAST(
+        CASE
+            WHEN ls.sum_value = 0 AND ts.sum_value = 0 THEN 0
+            WHEN ls.sum_value = 0 THEN 100.0
+            ELSE ABS(ts.sum_value - ls.sum_value) * 100.0 / ABS(ls.sum_value)
+        END
+        AS DECIMAL(18, 6)
+    ) AS delta_pct
+FROM legacy_sum ls
+CROSS JOIN target_sum ts;
+
+/* 3) sample 200 비교를 위한 키 추출 (lots 양쪽) + mismatch 계산 */
+WITH legacy_base AS (
+    SELECT
+        CONCAT(order_no, N'|', lot_no) AS sample_key,
+        CHECKSUM(order_no, lot_no, quantity, status) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.order_lots
+),
+target_base AS (
+    SELECT
+        CONCAT(order_no, N'|', lot_no) AS sample_key,
+        CHECKSUM(order_no, lot_no, quantity, status) AS row_hash
+    FROM [MES_HI].dbo.order_lots
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+)
+SELECT
+    COALESCE(l.sample_key, t.sample_key) AS sample_key,
+    l.row_hash AS legacy_hash,
+    t.row_hash AS target_hash,
+    CASE WHEN l.row_hash = t.row_hash AND l.sample_key IS NOT NULL AND t.sample_key IS NOT NULL THEN 0 ELSE 1 END AS is_mismatch
+FROM legacy_sample l
+FULL OUTER JOIN target_sample t
+    ON l.sample_key = t.sample_key
+ORDER BY sample_key;
+
+WITH legacy_base AS (
+    SELECT
+        CONCAT(order_no, N'|', lot_no) AS sample_key,
+        CHECKSUM(order_no, lot_no, quantity, status) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.order_lots
+),
+target_base AS (
+    SELECT
+        CONCAT(order_no, N'|', lot_no) AS sample_key,
+        CHECKSUM(order_no, lot_no, quantity, status) AS row_hash
+    FROM [MES_HI].dbo.order_lots
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+),
+merged AS (
+    SELECT
+        COALESCE(l.sample_key, t.sample_key) AS sample_key,
+        l.row_hash AS legacy_hash,
+        t.row_hash AS target_hash
+    FROM legacy_sample l
+    FULL OUTER JOIN target_sample t
+        ON l.sample_key = t.sample_key
+)
+SELECT
+    @Domain AS domain,
+    @SampleSize AS sample_size,
+    SUM(CASE WHEN legacy_hash = target_hash AND legacy_hash IS NOT NULL AND target_hash IS NOT NULL THEN 0 ELSE 1 END) AS sample_mismatch_count
+FROM merged;
+
+/* 4) status 분포 비교 (orders.status) + 편차(%p) */
+WITH legacy_dist AS (
+    SELECT status AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI_LEGACY].dbo.orders
+    GROUP BY status
+),
+target_dist AS (
+    SELECT status AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI].dbo.orders
+    GROUP BY status
+),
+legacy_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM legacy_dist
+),
+target_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM target_dist
+),
+merged AS (
+    SELECT
+        COALESCE(l.status_key, t.status_key) AS status_key,
+        ISNULL(l.cnt, 0) AS legacy_cnt,
+        ISNULL(t.cnt, 0) AS target_cnt
+    FROM legacy_dist l
+    FULL OUTER JOIN target_dist t
+        ON l.status_key = t.status_key
+)
+SELECT
+    @Domain AS domain,
+    status_key,
+    legacy_cnt,
+    target_cnt,
+    CAST(CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END AS DECIMAL(18, 6)) AS legacy_pct,
+    CAST(CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END AS DECIMAL(18, 6)) AS target_pct,
+    CAST(ABS(
+        (CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END)
+      - (CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END)
+    ) AS DECIMAL(18, 6)) AS delta_pct_point
+FROM merged
+CROSS JOIN legacy_total lt
+CROSS JOIN target_total tt
+ORDER BY status_key;

--- a/migration/sql/r1-validation/07-board-validation.sql
+++ b/migration/sql/r1-validation/07-board-validation.sql
@@ -1,0 +1,188 @@
+﻿/*
+  SCM-213 R1 Domain Validation SQL
+  Domain: board
+  목적: legacy vs target 비교 (count / sum / sample200 / status distribution)
+
+  기본 DB:
+    - Legacy : [MES_HI_LEGACY]
+    - Target : [MES_HI]
+
+  TODO:
+    - legacy DB명이 다르면 [MES_HI_LEGACY]를 실제 DB명으로 변경.
+    - legacy notice 컬럼이 is_notice가 아니면 legacy_base CTE의 notice_flag 매핑 수정.
+*/
+
+SET NOCOUNT ON;
+DECLARE @Domain NVARCHAR(30) = N'board';
+DECLARE @SampleSize INT = 200;
+
+/* 1) count 비교 (양쪽) */
+WITH legacy_base AS (
+    SELECT post_id, category_code, title, status, is_notice, created_at, updated_at
+    FROM [MES_HI_LEGACY].dbo.board_posts
+),
+target_base AS (
+    SELECT post_id, category_code, title, status, is_notice, created_at, updated_at
+    FROM [MES_HI].dbo.board_posts
+),
+legacy_count AS (
+    SELECT COUNT_BIG(1) AS cnt FROM legacy_base
+),
+target_count AS (
+    SELECT COUNT_BIG(1) AS cnt FROM target_base
+)
+SELECT
+    @Domain AS domain,
+    lc.cnt AS legacy_count,
+    tc.cnt AS target_count,
+    ABS(tc.cnt - lc.cnt) AS count_mismatch
+FROM legacy_count lc
+CROSS JOIN target_count tc;
+
+/* 2) sum 비교 (notice count) + 편차 계산 */
+WITH legacy_base AS (
+    SELECT
+        CASE
+            WHEN TRY_CONVERT(INT, is_notice) = 1 THEN 1
+            WHEN UPPER(CONVERT(NVARCHAR(10), is_notice)) IN (N'Y', N'TRUE') THEN 1
+            ELSE 0
+        END AS notice_flag
+    FROM [MES_HI_LEGACY].dbo.board_posts
+),
+target_base AS (
+    SELECT CASE WHEN is_notice = 1 THEN 1 ELSE 0 END AS notice_flag
+    FROM [MES_HI].dbo.board_posts
+),
+legacy_sum AS (
+    SELECT CAST(SUM(CAST(notice_flag AS DECIMAL(38, 6))) AS DECIMAL(38, 6)) AS sum_value FROM legacy_base
+),
+target_sum AS (
+    SELECT CAST(SUM(CAST(notice_flag AS DECIMAL(38, 6))) AS DECIMAL(38, 6)) AS sum_value FROM target_base
+)
+SELECT
+    @Domain AS domain,
+    ls.sum_value AS legacy_sum,
+    ts.sum_value AS target_sum,
+    CAST(ABS(ts.sum_value - ls.sum_value) AS DECIMAL(38, 6)) AS abs_delta,
+    CAST(
+        CASE
+            WHEN ls.sum_value = 0 AND ts.sum_value = 0 THEN 0
+            WHEN ls.sum_value = 0 THEN 100.0
+            ELSE ABS(ts.sum_value - ls.sum_value) * 100.0 / ABS(ls.sum_value)
+        END
+        AS DECIMAL(18, 6)
+    ) AS delta_pct
+FROM legacy_sum ls
+CROSS JOIN target_sum ts;
+
+/* 3) sample 200 비교를 위한 키 추출 (양쪽) + mismatch 계산 */
+WITH legacy_base AS (
+    SELECT
+        CAST(post_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(post_id AS NVARCHAR(64)), category_code, title, status, TRY_CONVERT(INT, is_notice)) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.board_posts
+),
+target_base AS (
+    SELECT
+        CAST(post_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(post_id AS NVARCHAR(64)), category_code, title, status, is_notice) AS row_hash
+    FROM [MES_HI].dbo.board_posts
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+)
+SELECT
+    COALESCE(l.sample_key, t.sample_key) AS sample_key,
+    l.row_hash AS legacy_hash,
+    t.row_hash AS target_hash,
+    CASE WHEN l.row_hash = t.row_hash AND l.sample_key IS NOT NULL AND t.sample_key IS NOT NULL THEN 0 ELSE 1 END AS is_mismatch
+FROM legacy_sample l
+FULL OUTER JOIN target_sample t
+    ON l.sample_key = t.sample_key
+ORDER BY sample_key;
+
+WITH legacy_base AS (
+    SELECT
+        CAST(post_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(post_id AS NVARCHAR(64)), category_code, title, status, TRY_CONVERT(INT, is_notice)) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.board_posts
+),
+target_base AS (
+    SELECT
+        CAST(post_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(post_id AS NVARCHAR(64)), category_code, title, status, is_notice) AS row_hash
+    FROM [MES_HI].dbo.board_posts
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+),
+merged AS (
+    SELECT
+        COALESCE(l.sample_key, t.sample_key) AS sample_key,
+        l.row_hash AS legacy_hash,
+        t.row_hash AS target_hash
+    FROM legacy_sample l
+    FULL OUTER JOIN target_sample t
+        ON l.sample_key = t.sample_key
+)
+SELECT
+    @Domain AS domain,
+    @SampleSize AS sample_size,
+    SUM(CASE WHEN legacy_hash = target_hash AND legacy_hash IS NOT NULL AND target_hash IS NOT NULL THEN 0 ELSE 1 END) AS sample_mismatch_count
+FROM merged;
+
+/* 4) status 분포 비교 (status) + 편차(%p) */
+WITH legacy_dist AS (
+    SELECT status AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI_LEGACY].dbo.board_posts
+    GROUP BY status
+),
+target_dist AS (
+    SELECT status AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI].dbo.board_posts
+    GROUP BY status
+),
+legacy_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM legacy_dist
+),
+target_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM target_dist
+),
+merged AS (
+    SELECT
+        COALESCE(l.status_key, t.status_key) AS status_key,
+        ISNULL(l.cnt, 0) AS legacy_cnt,
+        ISNULL(t.cnt, 0) AS target_cnt
+    FROM legacy_dist l
+    FULL OUTER JOIN target_dist t
+        ON l.status_key = t.status_key
+)
+SELECT
+    @Domain AS domain,
+    status_key,
+    legacy_cnt,
+    target_cnt,
+    CAST(CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END AS DECIMAL(18, 6)) AS legacy_pct,
+    CAST(CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END AS DECIMAL(18, 6)) AS target_pct,
+    CAST(ABS(
+        (CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END)
+      - (CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END)
+    ) AS DECIMAL(18, 6)) AS delta_pct_point
+FROM merged
+CROSS JOIN legacy_total lt
+CROSS JOIN target_total tt
+ORDER BY status_key;

--- a/migration/sql/r1-validation/08-quality-doc-validation.sql
+++ b/migration/sql/r1-validation/08-quality-doc-validation.sql
@@ -1,0 +1,185 @@
+﻿/*
+  SCM-213 R1 Domain Validation SQL
+  Domain: quality-doc
+  목적: legacy vs target 비교 (count / sum / sample200 / status distribution)
+
+  기본 DB:
+    - Legacy : [MES_HI_LEGACY]
+    - Target : [MES_HI]
+
+  TODO:
+    - legacy DB명이 다르면 [MES_HI_LEGACY]를 실제 DB명으로 변경.
+    - legacy quality_documents / quality_document_acks 컬럼명이 다르면 legacy CTE만 수정.
+*/
+
+SET NOCOUNT ON;
+DECLARE @Domain NVARCHAR(30) = N'quality-doc';
+DECLARE @SampleSize INT = 200;
+
+/* 1) count 비교 (documents + acks) */
+WITH legacy_docs AS (
+    SELECT document_id, title, document_type, issued_at, publisher_member_id, status
+    FROM [MES_HI_LEGACY].dbo.quality_documents
+),
+target_docs AS (
+    SELECT document_id, title, document_type, issued_at, publisher_member_id, status
+    FROM [MES_HI].dbo.quality_documents
+),
+legacy_acks AS (
+    SELECT document_id, member_id, ack_at
+    FROM [MES_HI_LEGACY].dbo.quality_document_acks
+),
+target_acks AS (
+    SELECT document_id, member_id, ack_at
+    FROM [MES_HI].dbo.quality_document_acks
+)
+SELECT
+    @Domain AS domain,
+    N'quality_documents' AS metric,
+    (SELECT COUNT_BIG(1) FROM legacy_docs) AS legacy_count,
+    (SELECT COUNT_BIG(1) FROM target_docs) AS target_count,
+    ABS((SELECT COUNT_BIG(1) FROM target_docs) - (SELECT COUNT_BIG(1) FROM legacy_docs)) AS count_mismatch
+UNION ALL
+SELECT
+    @Domain AS domain,
+    N'quality_document_acks' AS metric,
+    (SELECT COUNT_BIG(1) FROM legacy_acks) AS legacy_count,
+    (SELECT COUNT_BIG(1) FROM target_acks) AS target_count,
+    ABS((SELECT COUNT_BIG(1) FROM target_acks) - (SELECT COUNT_BIG(1) FROM legacy_acks)) AS count_mismatch;
+
+/* 2) sum 비교 (ack_count) + 편차 계산 */
+WITH legacy_sum AS (
+    SELECT CAST(COUNT_BIG(1) AS DECIMAL(38, 6)) AS sum_value
+    FROM [MES_HI_LEGACY].dbo.quality_document_acks
+),
+target_sum AS (
+    SELECT CAST(COUNT_BIG(1) AS DECIMAL(38, 6)) AS sum_value
+    FROM [MES_HI].dbo.quality_document_acks
+)
+SELECT
+    @Domain AS domain,
+    ls.sum_value AS legacy_sum,
+    ts.sum_value AS target_sum,
+    CAST(ABS(ts.sum_value - ls.sum_value) AS DECIMAL(38, 6)) AS abs_delta,
+    CAST(
+        CASE
+            WHEN ls.sum_value = 0 AND ts.sum_value = 0 THEN 0
+            WHEN ls.sum_value = 0 THEN 100.0
+            ELSE ABS(ts.sum_value - ls.sum_value) * 100.0 / ABS(ls.sum_value)
+        END
+        AS DECIMAL(18, 6)
+    ) AS delta_pct
+FROM legacy_sum ls
+CROSS JOIN target_sum ts;
+
+/* 3) sample 200 비교를 위한 키 추출 (documents 양쪽) + mismatch 계산 */
+WITH legacy_base AS (
+    SELECT
+        CAST(document_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(document_id AS NVARCHAR(64)), title, document_type, status, issued_at) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.quality_documents
+),
+target_base AS (
+    SELECT
+        CAST(document_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(document_id AS NVARCHAR(64)), title, document_type, status, issued_at) AS row_hash
+    FROM [MES_HI].dbo.quality_documents
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+)
+SELECT
+    COALESCE(l.sample_key, t.sample_key) AS sample_key,
+    l.row_hash AS legacy_hash,
+    t.row_hash AS target_hash,
+    CASE WHEN l.row_hash = t.row_hash AND l.sample_key IS NOT NULL AND t.sample_key IS NOT NULL THEN 0 ELSE 1 END AS is_mismatch
+FROM legacy_sample l
+FULL OUTER JOIN target_sample t
+    ON l.sample_key = t.sample_key
+ORDER BY sample_key;
+
+WITH legacy_base AS (
+    SELECT
+        CAST(document_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(document_id AS NVARCHAR(64)), title, document_type, status, issued_at) AS row_hash
+    FROM [MES_HI_LEGACY].dbo.quality_documents
+),
+target_base AS (
+    SELECT
+        CAST(document_id AS NVARCHAR(64)) AS sample_key,
+        CHECKSUM(CAST(document_id AS NVARCHAR(64)), title, document_type, status, issued_at) AS row_hash
+    FROM [MES_HI].dbo.quality_documents
+),
+legacy_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM legacy_base
+    ORDER BY sample_key
+),
+target_sample AS (
+    SELECT TOP (@SampleSize) sample_key, row_hash
+    FROM target_base
+    ORDER BY sample_key
+),
+merged AS (
+    SELECT
+        COALESCE(l.sample_key, t.sample_key) AS sample_key,
+        l.row_hash AS legacy_hash,
+        t.row_hash AS target_hash
+    FROM legacy_sample l
+    FULL OUTER JOIN target_sample t
+        ON l.sample_key = t.sample_key
+)
+SELECT
+    @Domain AS domain,
+    @SampleSize AS sample_size,
+    SUM(CASE WHEN legacy_hash = target_hash AND legacy_hash IS NOT NULL AND target_hash IS NOT NULL THEN 0 ELSE 1 END) AS sample_mismatch_count
+FROM merged;
+
+/* 4) status 분포 비교 (documents.status) + 편차(%p) */
+WITH legacy_dist AS (
+    SELECT status AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI_LEGACY].dbo.quality_documents
+    GROUP BY status
+),
+target_dist AS (
+    SELECT status AS status_key, COUNT_BIG(1) AS cnt
+    FROM [MES_HI].dbo.quality_documents
+    GROUP BY status
+),
+legacy_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM legacy_dist
+),
+target_total AS (
+    SELECT SUM(cnt) AS total_cnt FROM target_dist
+),
+merged AS (
+    SELECT
+        COALESCE(l.status_key, t.status_key) AS status_key,
+        ISNULL(l.cnt, 0) AS legacy_cnt,
+        ISNULL(t.cnt, 0) AS target_cnt
+    FROM legacy_dist l
+    FULL OUTER JOIN target_dist t
+        ON l.status_key = t.status_key
+)
+SELECT
+    @Domain AS domain,
+    status_key,
+    legacy_cnt,
+    target_cnt,
+    CAST(CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END AS DECIMAL(18, 6)) AS legacy_pct,
+    CAST(CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END AS DECIMAL(18, 6)) AS target_pct,
+    CAST(ABS(
+        (CASE WHEN lt.total_cnt = 0 THEN 0 ELSE legacy_cnt * 100.0 / lt.total_cnt END)
+      - (CASE WHEN tt.total_cnt = 0 THEN 0 ELSE target_cnt * 100.0 / tt.total_cnt END)
+    ) AS DECIMAL(18, 6)) AS delta_pct_point
+FROM merged
+CROSS JOIN legacy_total lt
+CROSS JOIN target_total tt
+ORDER BY status_key;


### PR DESCRIPTION
## Background/Goal\nImplement SCM-213 execution assets to run domain validation in fixed order (auth->member->file->inventory->report->order-lot->board->quality-doc) and store R1 report artifacts.\n\n## Scope\n- add domain SQL pack (8 files)\n- add R1 report template\n- add executable runner script for R1 validation\n\n## Commands\n- \\powershell -ExecutionPolicy Bypass -File .\\migration\\scripts\\run-r1-validation.ps1 -RunId R1-<timestamp>-DEV -SkipSqlExecution\\\n- \\powershell -ExecutionPolicy Bypass -File .\\migration\\scripts\\run-r1-validation.ps1 -RunId R1-<timestamp>-STG -Server <host,port> -User <user> -Password <pwd>\\\n\n## Linked Issue\n- Closes #19