### PR TITLE
SCM-214: rehearsal R1 runbook and go-nogo signoff flow

### DIFF
--- a/runbooks/gateway-routing-matrix.md
+++ b/runbooks/gateway-routing-matrix.md
@@ -1,0 +1,27 @@
+﻿# Gateway Routing Matrix (SCM-212)
+
+기준 정책 파일: `gateway/policies/cutover-isolation.yaml`
+
+| Domain | Path Prefix | Target Service | Auth Required | Timeout (ms) | Retry (attempts) | Circuit Breaker | Rate-Limit (rps) |
+|---|---|---|---|---:|---:|---|---:|
+| auth | `/api/auth/**` | `http://auth:8081` | N | 3000 | 1 | enabled, failureRate=40, slowCallRate=50, waitOpen=10000 | 120 |
+| member | `/api/member/**` | `http://member:8082` | Y | 5000 | 2 | enabled, failureRate=50, slowCallRate=50, waitOpen=10000 | 100 |
+| file | `/api/file/**` | `http://file:8087` | Y | 8000 | 1 | enabled, failureRate=50, slowCallRate=50, waitOpen=10000 | 60 |
+| inventory | `/api/inventory/**` | `http://inventory:8086` | Y | 5000 | 2 | enabled, failureRate=50, slowCallRate=50, waitOpen=10000 | 90 |
+| report | `/api/report/**` | `http://report:8088` | Y | 12000 | 0 | enabled, failureRate=30, slowCallRate=50, waitOpen=10000 | 40 |
+| order-lot (read) | `/api/order-lot/**` (`GET`) | `http://order-lot:8085` | Y | 10000 | 1 | enabled, failureRate=30, slowCallRate=50, waitOpen=10000 | 70 |
+| order-lot (write) | `/api/order-lot/**` (`POST`,`PUT`,`PATCH`,`DELETE`) | `http://order-lot:8085` | Y | 10000 | 0 | enabled, failureRate=30, slowCallRate=50, waitOpen=10000 | 30 |
+| board | `/api/board/**` | `http://board:8083` | Y | 5000 | 2 | enabled, failureRate=50, slowCallRate=50, waitOpen=10000 | 70 |
+| quality-doc | `/api/quality-doc/**` | `http://quality-doc:8084` | Y | 6000 | 1 | enabled, failureRate=40, slowCallRate=50, waitOpen=10000 | 60 |
+
+## 적용 규칙
+- 기본값: timeout=5000ms, retry=2, circuit-breaker(failureRate=50, slowCallRate=50, waitOpen=10000), rate-limit=80rps.
+- 도메인 override:
+  - `auth`: timeout 3000, retry 1, rate-limit 120.
+  - `report`: timeout 12000, retry 0, rate-limit 40.
+  - `order-lot`: read/write 분리 정책 적용(write retry=0).
+
+## 주의
+- 현재 gateway 정책 로더는 route별 timeout/retry/circuit-breaker 필드를 직접 해석하지 않는다.
+- runtime 적용은 `defaults` + `routes.rateLimitRps` + `writeProtection` 기반으로 동작한다.
+- 본 매트릭스의 route별 timeout/retry/circuit-breaker 값은 SCM-212 구현 기준값으로 운영 문서에 고정한다.

--- a/runbooks/go-nogo-signoff.md
+++ b/runbooks/go-nogo-signoff.md
@@ -1,26 +1,75 @@
-# Go / No-Go Sign-off
+﻿# SCM-214 Go/No-Go Sign-off (R1)
 
-## 대상 릴리즈
-- Target date:
-- Target scope:
-- Rehearsal references:
-  - 
-  - 
-  - 
+## 1) 실행 메타
+- RunId: `<R1-YYYYMMDD-HHMMSS-ENV>`
+- 기준 브랜치: `feature/to-be-dev-env-bootstrap`
+- 판정 대상: `SCM-210~214`
+- 판정 시점: `<yyyy-MM-dd HH:mm:ss>`
+- 증적 루트: `runbooks/evidence/<RunId>/`
 
-## 승인 기준 체크
-- [ ] 데이터 정합성(건수/합계/샘플) 100% 일치
-- [ ] P0 시나리오 smoke test 100% 통과
-- [ ] 보안 고위험 이슈 미해결 0건
-- [ ] 백업/복구 리허설 성공
-- [ ] 운영 모니터링/알림 정상
+## 2) 판정 입력물(필수)
+- [ ] `runbooks/evidence/<RunId>/gate-build.log`
+- [ ] `runbooks/evidence/<RunId>/gate-unit-integration.log`
+- [ ] `runbooks/evidence/<RunId>/gate-contract.log`
+- [ ] `runbooks/evidence/<RunId>/gate-smoke.log`
+- [ ] `runbooks/evidence/<RunId>/gate-migration-dry-run.log`
+- [ ] `migration/reports/validation-*.md` 최신 파일
+- [ ] Gateway/서비스 로그, Prometheus 쿼리 결과, SQL 결과 스냅샷
 
-## 최종 결정
-- [ ] Go
-- [ ] No-Go
-- 결정 사유:
+## 3) 전역 Go/No-Go 지표
 
-## 서명
-- Tech Owner:
-- Operation Owner:
-- Date:
+| 지표 | 측정 위치(로그/메트릭/SQL) | 샘플 커맨드/쿼리 | GO 임계치 | 임계치 초과 시 즉시 조치(런북 링크) | 에스컬레이션 트리거 |
+|---|---|---|---|---|---|
+| 5xx 오류율 | Prometheus (`http_server_requests_seconds_count`) | `Invoke-RestMethod "http://localhost:9090/api/v1/query?query=$([uri]::EscapeDataString('sum(rate(http_server_requests_seconds_count{uri=~"/api/.*",status=~"5.."}[5m]))/sum(rate(http_server_requests_seconds_count{uri=~"/api/.*"}[5m]))*100'))"` | `<= 0.5%` | 1) `GATEWAY_EMERGENCY_STOP_ENABLED=true` 2) 장애 도메인 route 제한 3) [rehearsal-R1-runbook](./rehearsal-R1-runbook.md), [rollback-playbook](./rollback-playbook.md) 실행 | 임계치 초과 10분 지속 또는 5분 내 상승 추세 |
+| 4xx 오류율 | Prometheus (`status=4..`) + gateway 로그 | `Invoke-RestMethod "http://localhost:9090/api/v1/query?query=$([uri]::EscapeDataString('sum(rate(http_server_requests_seconds_count{uri=~"/api/.*",status=~"4.."}[5m]))/sum(rate(http_server_requests_seconds_count{uri=~"/api/.*"}[5m]))*100'))"` | `<= 8.0%` | 1) 인증/권한 정책 오탐 확인 2) 계약/입력검증 차이 수정 3) [gateway-routing-matrix](./gateway-routing-matrix.md), [merge-gates-checklist](./merge-gates-checklist.md) 재검증 | 임계치 초과 10분 지속 |
+| p95 latency | Prometheus histogram | `Invoke-RestMethod "http://localhost:9090/api/v1/query?query=$([uri]::EscapeDataString('histogram_quantile(0.95,sum(rate(http_server_requests_seconds_bucket{uri=~"/api/.*"}[5m])) by (le))*1000'))"` | `<= 350ms` | 1) 고지연 도메인 rate-limit 하향 2) 쿼리/인덱스 확인 3) [today-execution-R1](./today-execution-R1.md) 성능 보강 절차 실행 | 임계치 초과 10분 지속 |
+| p99 latency | Prometheus histogram | `Invoke-RestMethod "http://localhost:9090/api/v1/query?query=$([uri]::EscapeDataString('histogram_quantile(0.99,sum(rate(http_server_requests_seconds_bucket{uri=~"/api/.*"}[5m])) by (le))*1000'))"` | `<= 700ms` | 1) 급증 API 일시 차단/제한 2) 장애 도메인 격리 3) [rehearsal-R1-runbook](./rehearsal-R1-runbook.md) Validation 재수행 | 임계치 초과 10분 지속 |
+| RabbitMQ 적체 | RabbitMQ Management API (`messages_ready`,`messages_unacknowledged`) | `$cred=New-Object PSCredential('guest',(ConvertTo-SecureString 'guest' -AsPlainText -Force));$q=Invoke-RestMethod -Uri 'http://localhost:15672/api/queues' -Credential $cred;($q|Measure-Object messages_ready -Sum).Sum;($q|Measure-Object messages_unacknowledged -Sum).Sum` | `ready <= 1000` AND `unacked <= 500` | 1) 소비자 상태 점검/재기동 2) 큐별 병목 제거 3) [today-execution-R1](./today-execution-R1.md) 운영 절차 실행 | 임계치 초과 10분 지속 또는 증가율 양수 10분 지속 |
+| DB deadlock/timeout | SQL Server system_health XEvent + 앱 로그 | `sqlcmd -S localhost,1433 -U sa -P <PWD> -d master -Q "SELECT SUM(CASE WHEN object_name='xml_deadlock_report' THEN 1 ELSE 0 END) deadlock_10m, SUM(CASE WHEN object_name='error_reported' AND CONVERT(xml,event_data).value('(event/data[@name=\"error_number\"]/value)[1]','int')=1222 THEN 1 ELSE 0 END) timeout_10m FROM sys.fn_xe_file_target_read_file('system_health*.xel',NULL,NULL,NULL) WHERE timestamp_utc>=DATEADD(MINUTE,-10,SYSUTCDATETIME());"` | `deadlock=0` AND `timeout<=3/10분` | 1) 장기 트랜잭션 종료 2) 락 경합 SQL 우회/튜닝 3) [rollback-playbook](./rollback-playbook.md) 대기 | deadlock 1건 즉시 또는 timeout 임계치 10분 지속 |
+| 데이터 정합성 오차율 | `migration/reports/validation-*.md` + 도메인 SQL 결과 | `$latest=Get-ChildItem migration/reports/validation-*.md|Sort LastWriteTime -Desc|Select -First 1;Get-Content $latest.FullName|Select-String 'TotalChecks|FailedChecks'` | `count mismatch=0`, `sum<=0.1%`, `sample mismatch=0/200`, `status<=1.0%p` | 1) 컷오버 중단 2) `migration/sql/r1-validation/*.sql` 재실행 3) [rehearsal-R1-runbook](./rehearsal-R1-runbook.md) Rollback 단계 수행 | 기준 1개라도 초과 시 즉시 |
+| 롤백 시간 | restore 실행 로그 + 측정 | `(Measure-Command { powershell -ExecutionPolicy Bypass -File .\scripts\restore-db.ps1 -BackupFile '<BACKUP.bak>' -Database 'MES_HI' -Staging }).TotalMinutes` | `<= 20분` | 1) 즉시 복원 수행 2) 미완료 시 트래픽 차단 유지 3) [rollback-playbook](./rollback-playbook.md) 절차 고정 | 20분 초과 즉시 |
+| 인증 실패율 | Prometheus(auth route 401/403) + auth/gateway 로그 | `Invoke-RestMethod "http://localhost:9090/api/v1/query?query=$([uri]::EscapeDataString('sum(rate(http_server_requests_seconds_count{uri=~"/api/auth/.*",status=~"401|403"}[5m]))/sum(rate(http_server_requests_seconds_count{uri=~"/api/auth/.*"}[5m]))*100'))"` | `<= 3.0%` | 1) 토큰 발급/검증 흐름 점검 2) 시크릿/만료 정책 확인 3) [gateway-routing-matrix](./gateway-routing-matrix.md) 및 auth 설정 재검증 | 임계치 초과 10분 지속 |
+
+## 4) Order-Lot 전용(강화) 임계치
+
+| 지표 (order-lot 전용) | 측정 위치 | 샘플 커맨드/쿼리 | GO 임계치(강화) | 임계치 초과 시 즉시 조치 | 에스컬레이션 트리거 |
+|---|---|---|---|---|---|
+| 5xx 오류율 | Prometheus (`uri=~"/api/order-lot/.*"`) | `Invoke-RestMethod "http://localhost:9090/api/v1/query?query=$([uri]::EscapeDataString('sum(rate(http_server_requests_seconds_count{uri=~"/api/order-lot/.*",status=~"5.."}[5m]))/sum(rate(http_server_requests_seconds_count{uri=~"/api/order-lot/.*"}[5m]))*100'))"` | `<= 0.2%` | 1) order-lot write 즉시 차단 2) read-only fallback 전환 3) [rehearsal-R1-runbook](./rehearsal-R1-runbook.md) Rollback 준비 | 5분 지속 |
+| p95 latency | Prometheus (`order-lot`) | `Invoke-RestMethod "http://localhost:9090/api/v1/query?query=$([uri]::EscapeDataString('histogram_quantile(0.95,sum(rate(http_server_requests_seconds_bucket{uri=~"/api/order-lot/.*"}[5m])) by (le))*1000'))"` | `<= 250ms` | 1) 고비용 쿼리 제한 2) write 요청 감속 3) [gateway-routing-matrix](./gateway-routing-matrix.md) rate-limit 하향 적용 | 5분 지속 |
+| p99 latency | Prometheus (`order-lot`) | `Invoke-RestMethod "http://localhost:9090/api/v1/query?query=$([uri]::EscapeDataString('histogram_quantile(0.99,sum(rate(http_server_requests_seconds_bucket{uri=~"/api/order-lot/.*"}[5m])) by (le))*1000'))"` | `<= 450ms` | 1) write 중단 2) read path만 유지 3) [rollback-playbook](./rollback-playbook.md) 준비 | 5분 지속 |
+| Write 실패율 | Prometheus (`method=POST|PUT|PATCH|DELETE`) | `Invoke-RestMethod "http://localhost:9090/api/v1/query?query=$([uri]::EscapeDataString('sum(rate(http_server_requests_seconds_count{uri=~"/api/order-lot/.*",method=~"POST|PUT|PATCH|DELETE",status=~"5..|4.."}[5m]))/sum(rate(http_server_requests_seconds_count{uri=~"/api/order-lot/.*",method=~"POST|PUT|PATCH|DELETE"}[5m]))*100'))"` | `<= 0.5%` | 1) write retry=0 유지 확인 2) write 보호 정책 즉시 적용 3) [gateway-routing-matrix](./gateway-routing-matrix.md) 확인 | 5분 지속 |
+| 데이터 정합성 | `migration/sql/r1-validation/06-order-lot-validation.sql` 결과 | `sqlcmd -S <server> -U <user> -P <pwd> -i migration/sql/r1-validation/06-order-lot-validation.sql -o migration/reports/R1-order-lot-output.txt` | `count=0`, `sum<=0.05%`, `sample=0/200`, `status<=0.5%p` | 1) 즉시 NO-GO 2) DB 복원 3) [rehearsal-R1-runbook](./rehearsal-R1-runbook.md) Rollback 실행 | 기준 1개라도 초과 즉시 |
+| DB deadlock/timeout (order-lot 관련) | app 로그 + SQL XEvent | `rg -n "order-lot|deadlock|timeout|1205|1222" logs\ -S` | `deadlock=0`, `timeout=0/10분` | 1) 해당 트랜잭션 차단 2) write 경로 중지 3) [rollback-playbook](./rollback-playbook.md) 실행 | 1건 발생 즉시 |
+
+## 5) 즉시 조치 우선순위
+1. 안전 확보: `GATEWAY_EMERGENCY_STOP_ENABLED=true` 또는 도메인 write 차단.
+2. 영향 축소: order-lot read-only fallback 유지, 고장 도메인 route rate-limit 하향.
+3. 근본 조치: SQL/인덱스/정책 수정 후 smoke + migration-dry-run 재검증.
+4. 복구 실패 시: `rollback-playbook` 수행 후 `NO-GO` 선언.
+
+## 6) 최종 판정 체크
+- [ ] 필수 게이트 5종 PASS (`build`, `unit-integration-test`, `contract-test`, `smoke-test`, `migration-dry-run`)
+- [ ] 전역 지표 임계치 전부 충족
+- [ ] order-lot 강화 지표 전부 충족
+- [ ] 데이터 정합성 기준 충족 (`count=0`, `sum<=0.1%`, `sample=0/200`, `status<=1.0%p`)
+- [ ] 롤백 시간 기준 충족 (`<=20분`)
+
+**결정 규칙**
+- 위 체크 중 1개라도 미충족이면 `NO-GO`.
+- order-lot 강화 지표 1개라도 미충족이면 `NO-GO`.
+
+## 7) 서명 섹션
+
+| 역할 | 승인자 | 승인 시간 (KST) | 결정 (GO/NO-GO) | 근거 링크 |
+|---|---|---|---|---|
+| Dev Owner | `<name>` | `<yyyy-MM-dd HH:mm:ss>` | `<GO/NO-GO>` | `<runbooks/evidence/...>` |
+| Codex (Validation) | `Codex` | `<yyyy-MM-dd HH:mm:ss>` | `<GO/NO-GO>` | `<migration/reports/validation-*.md>` |
+| Ops Owner | `<name>` | `<yyyy-MM-dd HH:mm:ss>` | `<GO/NO-GO>` | `<dashboard/log/restore evidence>` |
+| QA/Business Owner | `<name>` | `<yyyy-MM-dd HH:mm:ss>` | `<GO/NO-GO>` | `<UAT/rehearsal evidence>` |
+
+## 8) 참고 런북
+- [today-execution-R1](./today-execution-R1.md)
+- [rehearsal-R1-runbook](./rehearsal-R1-runbook.md)
+- [merge-gates-checklist](./merge-gates-checklist.md)
+- [gateway-routing-matrix](./gateway-routing-matrix.md)
+- [rollback-playbook](./rollback-playbook.md)

--- a/runbooks/merge-gates-checklist.md
+++ b/runbooks/merge-gates-checklist.md
@@ -1,0 +1,114 @@
+﻿# Merge Gates Checklist
+
+## 0) Evidence Path 고정
+```powershell
+$IssueKey = "SCM-210"   # 예: SCM-211, SCM-212 ...
+$RunTs = Get-Date -Format "yyyyMMdd-HHmmss"
+$EvDir = "runbooks/evidence/$IssueKey-$RunTs"
+New-Item -ItemType Directory -Force $EvDir | Out-Null
+```
+
+## 0-1) PR 체크 리포트 공백 대응 (필수)
+- `gh pr checks <PR번호>` 결과가 비어 있으면(`no checks reported`) **머지 금지**.
+- 아래 5개 로컬 게이트 로그를 PR 코멘트에 반드시 남긴 뒤에만 머지:
+  - `gate-build.log`
+  - `gate-unit-integration.log`
+  - `gate-contract.log`
+  - `gate-smoke.log`
+  - `gate-migration-dry-run.log`
+
+```powershell
+$PrNo = 0
+gh pr checks $PrNo | Tee-Object "$EvDir\gh-pr-checks.txt"
+```
+
+## 0-2) 순차 머지(rebase) 규칙 (필수)
+- 순서 의존 PR은 **앞 PR 머지 직후, 다음 PR 머지 직전에 rebase** 한다.
+- 예: `#16 -> #17 -> #18`이면 `#17/#18`은 merge 직전 rebase + force-push가 필수.
+
+```powershell
+git fetch origin
+git rebase origin/feature/to-be-dev-env-bootstrap
+git push --force-with-lease
+```
+
+## 1) 필수 게이트 실행/판정/즉시조치
+
+| Gate | 실행 커맨드 | 성공 판정 | 실패 시 즉시 조치 |
+|---|---|---|---|
+| build | `powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate build 2>&1 | Tee-Object "$EvDir\gate-build.log"` | exit code `0`, 로그 내 `[FAIL]` `0건` | 1) 머지 중단 2) `gate-build.log` 마지막 80줄 확인 3) 실패 모듈 단위 재실행(`.\gradlew.bat :<module>:build -x test`) 4) 수정 후 build 재실행 |
+| unit-integration-test | `powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate unit-integration-test 2>&1 | Tee-Object "$EvDir\gate-unit-integration.log"` | exit code `0`, 테스트 실패 `0건`, 오류 `0건` | 1) 머지 중단 2) 실패 테스트 단독 재현(`.\gradlew.bat test --tests "*ClassName*"`) 3) flaky 여부 확인 4) 수정 후 전체 test 재실행 |
+| contract-test | `powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate contract-test 2>&1 | Tee-Object "$EvDir\gate-contract.log"` | exit code `0`, `openapi: 3.x`/`paths` 누락 `0건` | 1) 머지 중단 2) 누락 파일 즉시 수정 3) `shared/contracts/*.openapi.yaml` diff 재검토 4) contract-test 재실행 |
+| smoke-test | `$env:SCM_ENABLE_GATEWAY_E2E_SMOKE="1"; powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate smoke-test 2>&1 | Tee-Object "$EvDir\gate-smoke.log"` | exit code `0`, smoke `[FAIL]` `0건`, smoke `[SKIP]` `0건` | 1) 머지 중단 2) auth/member/gateway health 확인 3) 포트/DB/env 재점검 4) `scripts\smoke-gateway-auth-member-e2e.ps1` 단독 재실행 |
+| migration-dry-run | `powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate migration-dry-run 2>&1 | Tee-Object "$EvDir\gate-migration-dry-run.log"` | exit code `0`, `migration/reports/validation-*.md` 최신 파일의 `FailedChecks: 0` | 1) 머지 중단 2) mismatch 유형(count/sum/sample/file) 분류 3) SQL/매핑 수정 4) dry-run + validate 재실행 |
+
+## 2) 게이트 일괄 실행 (복붙용)
+```powershell
+$IssueKey = "SCM-210"
+$RunTs = Get-Date -Format "yyyyMMdd-HHmmss"
+$EvDir = "runbooks/evidence/$IssueKey-$RunTs"
+New-Item -ItemType Directory -Force $EvDir | Out-Null
+
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate build 2>&1 | Tee-Object "$EvDir\gate-build.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate unit-integration-test 2>&1 | Tee-Object "$EvDir\gate-unit-integration.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate contract-test 2>&1 | Tee-Object "$EvDir\gate-contract.log"
+$env:SCM_ENABLE_GATEWAY_E2E_SMOKE="1"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate smoke-test 2>&1 | Tee-Object "$EvDir\gate-smoke.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate migration-dry-run 2>&1 | Tee-Object "$EvDir\gate-migration-dry-run.log"
+```
+
+## 3) PR 본문 첨부 증적 목록(필수)
+
+| 구분 | 파일/로그 | 저장 위치 |
+|---|---|---|
+| Gate log | `gate-build.log` | `runbooks/evidence/<ISSUE>-<TS>/` |
+| Gate log | `gate-unit-integration.log` | `runbooks/evidence/<ISSUE>-<TS>/` |
+| Gate log | `gate-contract.log` | `runbooks/evidence/<ISSUE>-<TS>/` |
+| Gate log | `gate-smoke.log` | `runbooks/evidence/<ISSUE>-<TS>/` |
+| Gate log | `gate-migration-dry-run.log` | `runbooks/evidence/<ISSUE>-<TS>/` |
+| Migration report | `validation-*.md` 최신 1개 | `migration/reports/` |
+| Migration state | `dryrun-*.state.json` 또는 `<RunId>.state.json` | `migration/reports/` |
+| Contract diff | `contracts-diff.txt` | `runbooks/evidence/<ISSUE>-<TS>/` |
+| PR checks text | `gh-pr-checks.txt` | `runbooks/evidence/<ISSUE>-<TS>/` |
+| Smoke detail | `smoke-gateway-auth-member-e2e.log` (선택) | `runbooks/evidence/<ISSUE>-<TS>/` |
+| Screenshot | `gh-checks.png` (선택) | `runbooks/evidence/<ISSUE>-<TS>/` |
+
+## 4) 증적 생성 커맨드
+```powershell
+# contract diff
+$contracts = git diff --name-only HEAD~1 HEAD -- shared/contracts | Out-String
+$contracts | Set-Content -Encoding UTF8 "$EvDir\contracts-diff.txt"
+
+# PR checks export
+$PrNo = 0  # 실제 PR 번호로 교체
+if ($PrNo -gt 0) {
+  gh pr checks $PrNo | Tee-Object "$EvDir\gh-pr-checks.txt"
+}
+
+# smoke 단독 로그 수집(필요 시)
+powershell -ExecutionPolicy Bypass -File .\scripts\smoke-gateway-auth-member-e2e.ps1 2>&1 | Tee-Object "$EvDir\smoke-gateway-auth-member-e2e.log"
+```
+
+## 5) PR 본문 붙여넣기 템플릿
+```markdown
+## Mandatory Gates
+- [x] build (log: `runbooks/evidence/<ISSUE>-<TS>/gate-build.log`)
+- [x] unit-integration-test (log: `runbooks/evidence/<ISSUE>-<TS>/gate-unit-integration.log`)
+- [x] contract-test (log: `runbooks/evidence/<ISSUE>-<TS>/gate-contract.log`)
+- [x] smoke-test (log: `runbooks/evidence/<ISSUE>-<TS>/gate-smoke.log`)
+- [x] migration-dry-run (log: `runbooks/evidence/<ISSUE>-<TS>/gate-migration-dry-run.log`)
+
+## Evidence
+- migration report: `migration/reports/validation-<TS>.md` (`FailedChecks: 0`)
+- contract diff: `runbooks/evidence/<ISSUE>-<TS>/contracts-diff.txt`
+- pr checks: `runbooks/evidence/<ISSUE>-<TS>/gh-pr-checks.txt`
+```
+
+## 6) Merge Block Rules
+- 아래 조건 중 하나라도 참이면 머지 금지:
+  - 필수 게이트 pass율 `100%` 미달
+  - smoke `[SKIP]` `1건` 이상
+  - migration `FailedChecks > 0`
+  - PR 증적 파일 누락 `1개` 이상
+  - `gh pr checks` 결과가 비어 있는데 로컬 5게이트 증적 코멘트가 없는 경우
+  - 순차 머지 대상 PR에서 merge 직전 rebase 증적(로그/코멘트)이 없는 경우

--- a/runbooks/rehearsal-R1-runbook.md
+++ b/runbooks/rehearsal-R1-runbook.md
@@ -1,0 +1,142 @@
+﻿# Rehearsal R1 Runbook (90-minute Target)
+
+## Fixed Scope
+- Scope: `SCM-210~214`
+- Priority: `Order-Lot P0`
+- Base branch: `feature/to-be-dev-env-bootstrap`
+- Mandatory gates before signoff: `build`, `unit-integration-test`, `contract-test`, `smoke-test`, `migration-dry-run`
+
+## 0) Run Variables
+```powershell
+$RunId = "R1-$(Get-Date -Format yyyyMMdd-HHmmss)"
+$EvDir = "runbooks/evidence/$RunId"
+New-Item -ItemType Directory -Force $EvDir | Out-Null
+```
+
+## 1) Prep (T+00 ~ T+15, 목표 15분)
+
+| 항목 | 담당 | 입력물 | 산출물 | 목표 시간 | 중단 조건 |
+|---|---|---|---|---:|---|
+| 환경 점검 | Dev | `toolchain.lock.json`, `.env.staging` | `prep-check-prereqs.log` | 5분 | `check-prereqs -Strict` 실패 |
+| 스테이징 기동 | Dev | Docker daemon `UP` | `prep-staging-up.log` | 5분 | `staging-up.ps1` 실패 |
+| DB 백업 | Dev | `MSSQL_SA_PASSWORD` | `prep-backup.log`, `.bak` 파일 | 5분 | 백업 파일 생성 실패 |
+
+Commands:
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\check-prereqs.ps1 -Strict 2>&1 | Tee-Object "$EvDir\prep-check-prereqs.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\staging-up.ps1 2>&1 | Tee-Object "$EvDir\prep-staging-up.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\backup-db.ps1 -Database "MES_HI" -Staging 2>&1 | Tee-Object "$EvDir\prep-backup.log"
+```
+
+## 2) Cutover (T+15 ~ T+35, 목표 20분)
+
+| 항목 | 담당 | 입력물 | 산출물 | 목표 시간 | 중단 조건 |
+|---|---|---|---|---:|---|
+| Auth/Member SQL 모드 기동 | Dev | DB 접속 env | `cutover-auth.log`, `cutover-member.log` | 10분 | health `UP` 실패 |
+| Gateway 정책 기동 | Dev | `infra/gateway/policies/local-auth-member-e2e.yaml` | `cutover-gateway.log` | 10분 | `/actuator/health` 실패 |
+
+Commands (각각 별도 터미널):
+```powershell
+# Terminal A (auth)
+$env:SCM_DB_URL="jdbc:sqlserver://localhost:1433;databaseName=MES_HI;encrypt=true;trustServerCertificate=true"
+$env:SCM_DB_USER="sa"
+$env:SCM_DB_PASSWORD="<MSSQL_SA_PASSWORD>"
+$env:SCM_DB_DRIVER="com.microsoft.sqlserver.jdbc.SQLServerDriver"
+$env:SCM_AUTH_JWT_SECRET="<32+ chars>"
+.\gradlew.bat :services:auth:bootRun 2>&1 | Tee-Object "$EvDir\cutover-auth.log"
+
+# Terminal B (member)
+$env:SCM_DB_URL="jdbc:sqlserver://localhost:1433;databaseName=MES_HI;encrypt=true;trustServerCertificate=true"
+$env:SCM_DB_USER="sa"
+$env:SCM_DB_PASSWORD="<MSSQL_SA_PASSWORD>"
+$env:SCM_DB_DRIVER="com.microsoft.sqlserver.jdbc.SQLServerDriver"
+.\gradlew.bat :services:member:bootRun 2>&1 | Tee-Object "$EvDir\cutover-member.log"
+
+# Terminal C (gateway)
+$env:GATEWAY_POLICY_PATH="infra/gateway/policies/local-auth-member-e2e.yaml"
+.\gradlew.bat :services:gateway:bootRun 2>&1 | Tee-Object "$EvDir\cutover-gateway.log"
+```
+
+Health check:
+```powershell
+Invoke-RestMethod http://localhost:8081/actuator/health | Tee-Object "$EvDir\health-auth.log"
+Invoke-RestMethod http://localhost:8082/actuator/health | Tee-Object "$EvDir\health-member.log"
+Invoke-RestMethod http://localhost:18080/actuator/health | Tee-Object "$EvDir\health-gateway.log"
+```
+
+## 3) Validation (T+35 ~ T+60, 목표 25분)
+
+| 항목 | 담당 | 입력물 | 산출물 | 목표 시간 | 중단 조건 |
+|---|---|---|---|---:|---|
+| Gateway E2E smoke | Dev | auth/member/gateway `UP` | `validation-smoke.log` | 10분 | smoke 실패 1건 이상 |
+| Migration dry-run + validate | Dev | migration config | `validation-dry-run.log`, `validation-report.log`, `migration/reports/validation-*.md` | 10분 | `FailedChecks > 0` |
+| 결과 집계 | Codex | 로그/리포트 | `validation-summary.md` | 5분 | 수치 누락 1건 이상 |
+
+Commands:
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\smoke-gateway-auth-member-e2e.ps1 2>&1 | Tee-Object "$EvDir\validation-smoke.log"
+powershell -ExecutionPolicy Bypass -File .\migration\scripts\dry-run.ps1 -RunId $RunId -OutputDir "migration/reports" -FailOnMismatch 2>&1 | Tee-Object "$EvDir\validation-dry-run.log"
+powershell -ExecutionPolicy Bypass -File .\migration\verify\validate-migration.ps1 -ConfigPath "migration/verify/config.sample.json" -OutputDir "migration/reports" -FailOnMismatch 2>&1 | Tee-Object "$EvDir\validation-report.log"
+```
+
+## 4) Rollback (optional, T+60 ~ T+80, 목표 20분)
+
+실행 조건:
+- 오류율 `> 1.0%` (5분 평균)
+- p95 latency `> 500ms` (핵심 API)
+- 데이터 mismatch `>= 1건`
+
+| 항목 | 담당 | 입력물 | 산출물 | 목표 시간 | 중단 조건 |
+|---|---|---|---|---:|---|
+| 백업 파일 선택 | Dev | `migration/backups/staging/*.bak` | 선택 파일명 기록 | 3분 | 사용 가능 백업 없음 |
+| DB 복구 | Dev | 백업 파일명 | `rollback-restore.log` | 12분 | restore 실패 |
+| 서비스 재검증 | Dev/Codex | restore 완료 | `rollback-health.log` | 5분 | health `UP` 실패 |
+
+Commands:
+```powershell
+# 최신 백업 파일 확인
+Get-ChildItem .\migration\backups\staging\*.bak | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+
+# 복구 실행 (<BACKUP_FILE> 교체)
+powershell -ExecutionPolicy Bypass -File .\scripts\restore-db.ps1 -BackupFile "<BACKUP_FILE>" -Database "MES_HI" -Staging 2>&1 | Tee-Object "$EvDir\rollback-restore.log"
+
+# 복구 후 health 재검증
+Invoke-RestMethod http://localhost:8081/actuator/health | Tee-Object "$EvDir\rollback-health.log"
+Invoke-RestMethod http://localhost:8082/actuator/health | Tee-Object -Append "$EvDir\rollback-health.log"
+Invoke-RestMethod http://localhost:18080/actuator/health | Tee-Object -Append "$EvDir\rollback-health.log"
+```
+
+## 5) Signoff (T+80 ~ T+90, 목표 10분)
+
+| 항목 | 담당 | 입력물 | 산출물 | 목표 시간 | 중단 조건 |
+|---|---|---|---|---:|---|
+| 수치 판정 | Codex | smoke/migration/gate 로그 | `runbooks/go-nogo-signoff.md` 업데이트 | 7분 | 임계치 충족 불가 |
+| 최종 승인 | Dev | signoff 문서 | 승인 코멘트/결론 | 3분 | 필수 증적 누락 1건 이상 |
+
+Commands:
+```powershell
+$env:SCM_ENABLE_GATEWAY_E2E_SMOKE="1"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate build 2>&1 | Tee-Object "$EvDir\signoff-gate-build.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate unit-integration-test 2>&1 | Tee-Object "$EvDir\signoff-gate-unit-integration.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate contract-test 2>&1 | Tee-Object "$EvDir\signoff-gate-contract.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate smoke-test 2>&1 | Tee-Object "$EvDir\signoff-gate-smoke.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate migration-dry-run 2>&1 | Tee-Object "$EvDir\signoff-gate-migration.log"
+```
+
+## Go/No-Go 판정 테이블 (임계치 고정)
+
+| 지표 | 측정 방법 | Go 기준 | No-Go 기준 |
+|---|---|---|---|
+| API 오류율 | smoke + 게이트 로그(5분 평균) | `<= 1.0%` | `> 1.0%` |
+| 핵심 API p95 latency | Order-Lot/Member API 측정 | `<= 350ms` | `> 500ms` |
+| 데이터 오차율(count/sum/sample/state) | `migration/reports/validation-*.md` | count mismatch `0`, sum delta `<= 0.1%`, sample mismatch `0`, state delta `<= 1.0%p` | 기준 1개라도 초과 |
+| smoke 결과 | `scripts/smoke-gateway-auth-member-e2e.ps1` | 실패 `0건` | 실패 `>= 1건` |
+| 필수 게이트 | `ci-run-gate.ps1` 5종 | pass `100%` | fail `>= 1건` |
+| 롤백 시간(필요 시) | restore 시작~health UP | `<= 20분` | `> 20분` |
+| 증적 완결성 | EvDir + migration/reports + QnA | 누락 `0건` | 누락 `>= 1건` |
+
+## Completion Outputs
+- `runbooks/evidence/<RunId>/` 전체 로그
+- `migration/reports/validation-*.md` 최신 리포트
+- `runbooks/go-nogo-signoff.md` 판정 반영본
+- `doc/QnA_보고서.md` 리허설 기록 반영

--- a/runbooks/today-execution-R1.md
+++ b/runbooks/today-execution-R1.md
@@ -1,0 +1,185 @@
+﻿# Today Execution R1 (2026-02-26)
+
+## Fixed Context
+- Base branch: `feature/to-be-dev-env-bootstrap`
+- Principle: `1 Issue = 1 PR = 1 dedicated branch`
+- Mandatory gates: `build`, `unit-integration-test`, `contract-test`, `smoke-test`, `migration-dry-run`
+- Artifact paths:
+  - Contracts: `shared/contracts/`
+  - Migration reports: `migration/reports/`
+  - Operations/Rehearsal: `runbooks/`
+  - QnA: `doc/QnA_보고서.md`
+- Today scope: `SCM-210~214` (`SCM-210 Order-Lot P0` first)
+
+## 0) One-time Setup (09:00 이전 1회)
+```powershell
+$RunDate = Get-Date -Format "yyyy-MM-dd"
+$RunId = "R1-$RunDate"
+$EvidenceDir = "runbooks/evidence/$RunDate"
+New-Item -ItemType Directory -Force $EvidenceDir | Out-Null
+```
+
+## 1) 09:00-09:30
+- Track A (Dev): 기준 브랜치 동기화 + 도구/포트 점검
+- Track B (Codex): 산출물 디렉터리 생성 + 게이트 로그 파일 경로 고정
+- Checkpoint:
+  - `git status` clean
+  - `check-prereqs` mismatch `0`
+  - Docker daemon `UP`
+  - 포트 충돌 `0건` (`8081,8082,18080,11433,35672`)
+- Commands:
+```powershell
+git fetch --all --prune
+git switch feature/to-be-dev-env-bootstrap
+git pull --ff-only
+powershell -ExecutionPolicy Bypass -File .\scripts\check-prereqs.ps1 -Strict 2>&1 | Tee-Object "$EvidenceDir\check-prereqs.log"
+docker info | Out-Null
+Get-NetTCPConnection -State Listen | Where-Object { $_.LocalPort -in 8081,8082,18080,11433,35672 } | Sort-Object LocalPort | Tee-Object "$EvidenceDir\ports.log"
+```
+- Stop condition:
+  - `check-prereqs` 실패
+  - Docker daemon down
+  - 포트 충돌 1건 이상이 10분 내 해소되지 않음
+
+## 2) 09:30-10:00
+- Track A (Dev): SCM-210~214 이슈 생성
+- Track B (Codex): 이슈-브랜치 매핑 표 작성
+- Checkpoint:
+  - Open issue 정확히 `5건` 생성 (`SCM-210~214`)
+  - 각 이슈 제목 prefix `[SCM-xxx]` 일치율 `100%`
+- Commands:
+```powershell
+gh issue create --title "[SCM-210] Order-Lot P0 API MVP" --body "Order-Lot P0 API MVP implementation with measurable DoD"
+gh issue create --title "[SCM-211] Board + Quality-Doc MVP" --body "Board and Quality-Doc MVP APIs with measurable DoD"
+gh issue create --title "[SCM-212] Gateway policy expansion (all domains)" --body "Gateway routing/policy across auth/member/file/inventory/report/order-lot/board/quality-doc"
+gh issue create --title "[SCM-213] Migration mapping/validation report R1" --body "Domain validation SQL and evidence"
+gh issue create --title "[SCM-214] Rehearsal R1 + Go/No-Go update" --body "90-minute rehearsal and Go/No-Go thresholds"
+gh issue list --state open --limit 30 | Tee-Object "$EvidenceDir\issue-list.log"
+```
+- Stop condition:
+  - 이슈 생성 실패 1건 이상
+  - 중복/오표기 이슈 발생 후 10분 내 정리 실패
+
+## 3) 10:00-11:00
+- Track A (Dev): `SCM-210` 전용 브랜치 생성 + Order-Lot 계약 고정
+- Track B (Codex): `SCM-213` 검증 SQL 템플릿 초안 생성
+- Checkpoint:
+  - 브랜치 `feature/scm-210-order-lot-p0-mvp` 생성
+  - `shared/contracts/order-lot.openapi.yaml` 최소 엔드포인트 정의 `100%`
+  - 필수 엔드포인트: `order create/read`, `lot assign/read`
+- Commands:
+```powershell
+git switch -c feature/scm-210-order-lot-p0-mvp
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate contract-test 2>&1 | Tee-Object "$EvidenceDir\scm210-contract-test.log"
+```
+- Stop condition:
+  - contract-test 실패
+  - 계약 파일에서 `openapi`, `paths` 누락 1건 이상
+
+## 4) 11:00-12:00
+- Track A (Dev): `SCM-210` API 골격 구현(Controller/Service/Repository)
+- Track B (Codex): Order-Lot 성능 측정 스크립트 초안 + 체크리스트 고정
+- Checkpoint:
+  - `:services:order-lot:test` 통과
+  - API 기본 에러코드(400/401/404/500) 매핑 `100%`
+- Commands:
+```powershell
+.\gradlew.bat :services:order-lot:test 2>&1 | Tee-Object "$EvidenceDir\scm210-order-lot-test.log"
+```
+- Stop condition:
+  - 테스트 실패 1건 이상
+  - 핵심 API(주문/LOT) 미구현 상태로 12:00 도달
+
+## 5) 13:00-14:00
+- Track A (Dev): `SCM-211` 전용 브랜치 생성 + Board/Quality-Doc 계약 고정
+- Track B (Codex): Gateway 정책 매트릭스 작성(`SCM-212` 입력물)
+- Checkpoint:
+  - 브랜치 `feature/scm-211-board-qualitydoc-mvp` 생성
+  - `board.openapi.yaml`, `quality-doc.openapi.yaml` contract-test 통과
+- Commands:
+```powershell
+git switch feature/to-be-dev-env-bootstrap
+git switch -c feature/scm-211-board-qualitydoc-mvp
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate contract-test 2>&1 | Tee-Object "$EvidenceDir\scm211-contract-test.log"
+```
+- Stop condition:
+  - 계약 테스트 실패
+  - 14:00 시점에도 엔드포인트 정의율 100% 미달
+
+## 6) 14:00-15:00
+- Track A (Dev): `SCM-212` 전용 브랜치 생성 + gateway 라우팅/정책 반영
+- Track B (Codex): 도메인별 timeout/retry/circuit-breaker/rate-limit 수치 확정
+- Checkpoint:
+  - 브랜치 `feature/scm-212-gateway-policy-all-domains` 생성
+  - 도메인 라우트 등록률 `100%` (8개 도메인)
+- Commands:
+```powershell
+git switch feature/to-be-dev-env-bootstrap
+git switch -c feature/scm-212-gateway-policy-all-domains
+$env:GATEWAY_POLICY_PATH="infra/gateway/policies/cutover-isolation.yaml"
+.\gradlew.bat :services:gateway:test 2>&1 | Tee-Object "$EvidenceDir\scm212-gateway-test.log"
+```
+- Stop condition:
+  - gateway 라우트 누락 1개 이상
+  - auth verify 연동 실패(401/200 판정 오류) 1건 이상
+
+## 7) 15:00-16:00
+- Track A (Dev): `SCM-213` 전용 브랜치 생성 + dry-run/정합성 검증
+- Track B (Codex): R1 검증 리포트 파일 생성/정리
+- Checkpoint:
+  - `FailedChecks: 0`
+  - count mismatch `0건`
+  - sum delta `<= 0.1%`
+- Commands:
+```powershell
+git switch feature/to-be-dev-env-bootstrap
+git switch -c feature/scm-213-migration-validation-r1
+powershell -ExecutionPolicy Bypass -File .\migration\scripts\dry-run.ps1 -RunId "R1-20260226" -OutputDir "migration/reports" -FailOnMismatch 2>&1 | Tee-Object "$EvidenceDir\scm213-dry-run.log"
+powershell -ExecutionPolicy Bypass -File .\migration\verify\validate-migration.ps1 -ConfigPath "migration/verify/config.sample.json" -OutputDir "migration/reports" -FailOnMismatch 2>&1 | Tee-Object "$EvidenceDir\scm213-validate.log"
+```
+- Stop condition:
+  - `FailedChecks > 0`
+  - dry-run/validation exit code non-zero
+
+## 8) 16:00-17:00
+- Track A (Dev): `SCM-210` 브랜치 기준 필수 게이트 5개 일괄 실행
+- Track B (Codex): PR 증적 패키지 구성
+- Checkpoint:
+  - 5개 게이트 pass `100%`
+  - smoke skip `0건`
+- Commands:
+```powershell
+git switch feature/scm-210-order-lot-p0-mvp
+$env:SCM_ENABLE_GATEWAY_E2E_SMOKE="1"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate build 2>&1 | Tee-Object "$EvidenceDir\gate-build.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate unit-integration-test 2>&1 | Tee-Object "$EvidenceDir\gate-unit-integration.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate contract-test 2>&1 | Tee-Object "$EvidenceDir\gate-contract.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate smoke-test 2>&1 | Tee-Object "$EvidenceDir\gate-smoke.log"
+powershell -ExecutionPolicy Bypass -File .\scripts\ci-run-gate.ps1 -Gate migration-dry-run 2>&1 | Tee-Object "$EvidenceDir\gate-migration-dry-run.log"
+```
+- Stop condition:
+  - 게이트 실패 1건 이상
+  - smoke 로그에 `[SKIP]` 1건 이상
+
+## 9) 17:00-18:00
+- Track A (Dev): `SCM-214` 전용 브랜치 생성 + 리허설 R1 실행
+- Track B (Codex): Go/No-Go 판정표 작성/업데이트
+- Checkpoint:
+  - 리허설 총 소요시간 `<= 90분`
+  - Critical 실패 `0건`
+  - 데이터 mismatch `0건`
+- Commands:
+```powershell
+git switch feature/to-be-dev-env-bootstrap
+git switch -c feature/scm-214-rehearsal-r1-signoff
+powershell -ExecutionPolicy Bypass -File .\scripts\rehearsal-run.ps1 -FailOnMismatch 2>&1 | Tee-Object "$EvidenceDir\scm214-rehearsal.log"
+```
+- Stop condition:
+  - 리허설 실패
+  - 롤백 필요 상태에서 20분 내 복구 실패
+
+## End-of-day Output Checklist
+- `runbooks/evidence/<date>/gate-*.log` 5개
+- `migration/reports/validation-*.md` 최신 1개 이상
+- `shared/contracts/*.openapi.yaml` 변경분 커밋 반영
+- `doc/QnA_보고서.md` 당일 QnA 반영

--- a/scripts/scm214-rehearsal-r1.ps1
+++ b/scripts/scm214-rehearsal-r1.ps1
@@ -1,0 +1,88 @@
+param(
+  [string]$RunId = "",
+  [switch]$SkipExecution
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+
+if ([string]::IsNullOrWhiteSpace($RunId)) {
+  $RunId = "R1-{0}" -f (Get-Date -Format "yyyyMMdd-HHmmss")
+}
+
+$evDir = Join-Path $repoRoot ("runbooks/evidence/{0}" -f $RunId)
+New-Item -ItemType Directory -Force -Path $evDir | Out-Null
+
+$gateList = @(
+  "build",
+  "unit-integration-test",
+  "contract-test",
+  "smoke-test",
+  "migration-dry-run"
+)
+
+$results = @()
+
+if (-not $SkipExecution) {
+  $rehearsalScript = Join-Path $repoRoot "scripts/rehearsal-run.ps1"
+  if (-not (Test-Path $rehearsalScript)) {
+    throw "Missing script: $rehearsalScript"
+  }
+
+  & powershell -ExecutionPolicy Bypass -File $rehearsalScript -FailOnMismatch 2>&1 | Tee-Object (Join-Path $evDir "rehearsal-run.log")
+  if ($LASTEXITCODE -ne 0) {
+    throw "rehearsal-run failed."
+  }
+
+  foreach ($gate in $gateList) {
+    $logPath = Join-Path $evDir ("gate-{0}.log" -f $gate)
+    if ($gate -eq "smoke-test") {
+      $env:SCM_ENABLE_GATEWAY_E2E_SMOKE = "1"
+    }
+    & powershell -ExecutionPolicy Bypass -File (Join-Path $repoRoot "scripts/ci-run-gate.ps1") -Gate $gate 2>&1 | Tee-Object $logPath
+    $passed = ($LASTEXITCODE -eq 0)
+    $results += [pscustomobject]@{
+      Gate = $gate
+      Passed = $passed
+      LogPath = $logPath
+    }
+    if (-not $passed) {
+      throw ("gate failed: {0}" -f $gate)
+    }
+  }
+}
+
+$summaryPath = Join-Path $evDir "signoff-input.md"
+$sb = New-Object System.Text.StringBuilder
+[void]$sb.AppendLine("# SCM-214 Signoff Input")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine(("- RunId: {0}" -f $RunId))
+[void]$sb.AppendLine(("- GeneratedAt: {0}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss")))
+[void]$sb.AppendLine(("- EvidenceDir: {0}" -f $evDir))
+[void]$sb.AppendLine(("- ExecutionMode: {0}" -f ($(if ($SkipExecution) { "SKIPPED" } else { "FULL" }))))
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("## Mandatory Gate Results")
+[void]$sb.AppendLine("| Gate | Result | Log |")
+[void]$sb.AppendLine("|---|---|---|")
+if ($results.Count -eq 0) {
+  foreach ($gate in $gateList) {
+    [void]$sb.AppendLine(("| {0} | PENDING | runbooks/evidence/{1}/gate-{0}.log |" -f $gate, $RunId))
+  }
+}
+else {
+  foreach ($r in $results) {
+    $resultText = if ($r.Passed) { "PASS" } else { "FAIL" }
+    $rel = $r.LogPath.Replace(($repoRoot.Path + "\"), "")
+    [void]$sb.AppendLine(("| {0} | {1} | {2} |" -f $r.Gate, $resultText, $rel))
+  }
+}
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("## Signoff Document")
+[void]$sb.AppendLine("- Update: runbooks/go-nogo-signoff.md")
+[void]$sb.AppendLine("- Required links:")
+[void]$sb.AppendLine("  - runbooks/evidence/<RunId>/gate-*.log")
+[void]$sb.AppendLine("  - migration/reports/validation-*.md latest")
+[void]$sb.AppendLine("  - smoke log and metric snapshots")
+
+$sb.ToString() | Set-Content -Encoding UTF8 $summaryPath
+Write-Host ("[OK] Signoff input generated: {0}" -f $summaryPath)


### PR DESCRIPTION
## Background/Goal\nImplement SCM-214 execution artifacts for 90-minute R1 rehearsal and measurable go/no-go signoff.\n\n## Scope\n- add rehearsal runbook (Prep/Cutover/Validation/Rollback/Signoff)\n- add go-nogo signoff thresholds and evidence links\n- add merge gate checklist with mandatory handling for empty PR checks and rebase-before-merge order\n- add helper script to generate signoff input bundle\n\n## Commands\n- \\powershell -ExecutionPolicy Bypass -File .\\scripts\\scm214-rehearsal-r1.ps1 -RunId R1-<timestamp> -SkipExecution\\\n- \\powershell -ExecutionPolicy Bypass -File .\\scripts\\scm214-rehearsal-r1.ps1 -RunId R1-<timestamp>\\\n\n## Linked Issue\n- Closes #20