### PR TITLE
fix(scm-217): stabilize rehearsal smoke and route resilience

### DIFF
--- a/doc/QnA_보고서.md
+++ b/doc/QnA_보고서.md
@@ -1154,3 +1154,27 @@ Java 21로 업그레이드(현재 17) 및 버전 고정 정책 적용
     - 주요 포트 점검: 8080(httpd 추정)만 LISTEN, 서비스 개발 포트(8081/8082/18080) 비점유
     - 워킹트리 변경사항/다중 worktree 존재 상태 확인 완료
 
+### Q85. gateway 504 대응 권장안 실행
+- 사용자 프롬프트:
+  - "추천하는 대응방안은?"
+  - "진행해줘"
+- Codex 답변(결과):
+  - 원인 고정: gateway 로그에서 `circuitBreaker` 1000ms 타임리미터 초과로 504 발생 확인
+  - 단기 안정화 반영:
+    - `infra/gateway/policies/local-auth-member-e2e.yaml`
+      - auth/member 라우트 CB 비활성화
+      - 로컬 E2E에서 글로벌 rate-limit/emergency-stop 비활성화
+    - `scripts/smoke-gateway-auth-member-e2e.ps1`
+      - login pre-warm 1회 호출 추가
+      - login 504 발생 시 1회 재시도 추가
+    - `scripts/ci-run-gate.ps1`
+      - gateway e2e smoke 1회 재시도 추가
+  - 구조 개선 반영:
+    - `GatewayResilienceConfiguration.java`
+      - 정책 기반 route CB(`cb-{routeId}`) 동적 구성
+      - route time-limiter를 `max(3000ms, requestTimeoutMs)`로 연동
+    - `GatewayRouteConfiguration.java`, `GatewayPolicyLoader.java`, `GatewayRoutePolicyResolver.java` 및 테스트 보강
+  - 검증:
+    - 5게이트 재실행: build / unit-integration-test / contract-test / smoke-test / migration-dry-run 모두 PASS
+    - smoke e2e에서 login/verify/member 조회/401 시나리오 PASS 확인
+

--- a/infra/gateway/policies/local-auth-member-e2e.yaml
+++ b/infra/gateway/policies/local-auth-member-e2e.yaml
@@ -16,7 +16,7 @@ defaults:
 
 trafficControl:
   globalRateLimit:
-    enabled: true
+    enabled: false
     requestsPerSecond: 300
     burstCapacity: 600
 
@@ -25,16 +25,20 @@ routes:
     path: /api/auth/**
     target: http://localhost:8081
     authRequired: false
-    rateLimitRps: 80
+    rateLimitRps: 0
+    circuitBreaker:
+      enabled: false
   - id: member
     path: /api/member/**
     target: http://localhost:8082
     authRequired: true
-    rateLimitRps: 80
+    rateLimitRps: 0
+    circuitBreaker:
+      enabled: false
 
 cutoverSwitches:
   blockLegacyWrites: false
   allowReadOnlyFallback: true
   emergencyStop:
-    enabled: true
+    enabled: false
     httpStatus: 503

--- a/scripts/ci-run-gate.ps1
+++ b/scripts/ci-run-gate.ps1
@@ -153,9 +153,34 @@ function Invoke-SmokeTest {
   }
 
   if ($env:SCM_ENABLE_GATEWAY_E2E_SMOKE -eq "1") {
-    & powershell -ExecutionPolicy Bypass -File $gatewayE2ESmoke
-    if ($LASTEXITCODE -ne 0) {
-      throw "[FAIL] smoke-test: gateway auth/member e2e smoke failed."
+    $smokeArgs = @()
+    if (-not [string]::IsNullOrWhiteSpace($env:SCM_GATEWAY_BASE_URL)) {
+      $smokeArgs += @("-GatewayBaseUrl", $env:SCM_GATEWAY_BASE_URL)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:SCM_SQL_CONTAINER_NAME)) {
+      $smokeArgs += @("-SqlContainerName", $env:SCM_SQL_CONTAINER_NAME)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:SCM_ENV_FILE)) {
+      $smokeArgs += @("-EnvFile", $env:SCM_ENV_FILE)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:SCM_DB_NAME)) {
+      $smokeArgs += @("-Database", $env:SCM_DB_NAME)
+    }
+    $smokePassed = $false
+    $maxAttempts = 2
+    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+      & powershell -ExecutionPolicy Bypass -File $gatewayE2ESmoke @smokeArgs
+      if ($LASTEXITCODE -eq 0) {
+        $smokePassed = $true
+        break
+      }
+      if ($attempt -lt $maxAttempts) {
+        Write-Host "[WARN] smoke-test: gateway auth/member e2e failed. retrying once..."
+        Start-Sleep -Seconds 1
+      }
+    }
+    if (-not $smokePassed) {
+      throw "[FAIL] smoke-test: gateway auth/member e2e smoke failed after retry."
     }
     Write-Host "[OK] smoke-test: gateway auth/member e2e smoke passed."
   }

--- a/scripts/scm214-rehearsal-r1.ps1
+++ b/scripts/scm214-rehearsal-r1.ps1
@@ -23,14 +23,36 @@ $gateList = @(
 
 $results = @()
 
+function Invoke-LoggedPowerShell {
+  param(
+    [Parameter(Mandatory = $true)][string]$ArgumentLine,
+    [Parameter(Mandatory = $true)][string]$LogPath
+  )
+
+  $errPath = "$LogPath.err"
+  if (Test-Path $LogPath) { Remove-Item -Force $LogPath }
+  if (Test-Path $errPath) { Remove-Item -Force $errPath }
+
+  $proc = Start-Process -FilePath "powershell" -ArgumentList $ArgumentLine -Wait -PassThru -WindowStyle Hidden -RedirectStandardOutput $LogPath -RedirectStandardError $errPath
+  if (Test-Path $errPath) {
+    $err = Get-Content -Raw -Encoding UTF8 $errPath
+    if (-not [string]::IsNullOrWhiteSpace($err)) {
+      Add-Content -Path $LogPath -Value $err -Encoding UTF8
+    }
+    Remove-Item -Force $errPath
+  }
+  return $proc.ExitCode
+}
+
 if (-not $SkipExecution) {
   $rehearsalScript = Join-Path $repoRoot "scripts/rehearsal-run.ps1"
   if (-not (Test-Path $rehearsalScript)) {
     throw "Missing script: $rehearsalScript"
   }
 
-  & powershell -ExecutionPolicy Bypass -File $rehearsalScript -FailOnMismatch 2>&1 | Tee-Object (Join-Path $evDir "rehearsal-run.log")
-  if ($LASTEXITCODE -ne 0) {
+  $rehearsalLog = Join-Path $evDir "rehearsal-run.log"
+  $rehearsalExit = Invoke-LoggedPowerShell -ArgumentLine ("-ExecutionPolicy Bypass -File `"{0}`" -FailOnMismatch" -f $rehearsalScript) -LogPath $rehearsalLog
+  if ($rehearsalExit -ne 0) {
     throw "rehearsal-run failed."
   }
 
@@ -38,9 +60,19 @@ if (-not $SkipExecution) {
     $logPath = Join-Path $evDir ("gate-{0}.log" -f $gate)
     if ($gate -eq "smoke-test") {
       $env:SCM_ENABLE_GATEWAY_E2E_SMOKE = "1"
+      if (-not $env:SCM_SQL_CONTAINER_NAME) {
+        $env:SCM_SQL_CONTAINER_NAME = "scm-stg-sqlserver"
+      }
+      if (-not $env:SCM_ENV_FILE) {
+        $env:SCM_ENV_FILE = ".env.staging"
+      }
+      if (-not $env:SCM_DB_NAME) {
+        $env:SCM_DB_NAME = "MES_HI"
+      }
     }
-    & powershell -ExecutionPolicy Bypass -File (Join-Path $repoRoot "scripts/ci-run-gate.ps1") -Gate $gate 2>&1 | Tee-Object $logPath
-    $passed = ($LASTEXITCODE -eq 0)
+    $gateScript = Join-Path $repoRoot "scripts/ci-run-gate.ps1"
+    $gateExit = Invoke-LoggedPowerShell -ArgumentLine ("-ExecutionPolicy Bypass -File `"{0}`" -Gate {1}" -f $gateScript, $gate) -LogPath $logPath
+    $passed = ($gateExit -eq 0)
     $results += [pscustomobject]@{
       Gate = $gate
       Passed = $passed

--- a/scripts/smoke-gateway-auth-member-e2e.ps1
+++ b/scripts/smoke-gateway-auth-member-e2e.ps1
@@ -75,6 +75,19 @@ function Assert-ExpectedStatusCode {
   }
 }
 
+function Invoke-Login {
+  param(
+    [Parameter(Mandatory = $true)][string]$Uri,
+    [Parameter(Mandatory = $true)][string]$LoginIdValue,
+    [Parameter(Mandatory = $true)][string]$PasswordValue
+  )
+
+  return Invoke-RestMethod -Method Post -Uri $Uri -ContentType "application/json" -Body (@{
+    loginId = $LoginIdValue
+    password = $PasswordValue
+  } | ConvertTo-Json)
+}
+
 function Seed-SmokeData {
   param(
     [Parameter(Mandatory = $true)][string]$RepoRoot,
@@ -231,18 +244,42 @@ try {
   $memberByIdUri = "$GatewayBaseUrl/api/member/v1/members/$LoginId"
 
   try {
-    $loginResponse = Invoke-RestMethod -Method Post -Uri $loginUri -ContentType "application/json" -Body (@{
-      loginId = $LoginId
-      password = $Password
-    } | ConvertTo-Json)
+    Invoke-Login -Uri $loginUri -LoginIdValue $LoginId -PasswordValue $Password | Out-Null
+    Write-Host "[INFO] login pre-warm request completed."
   }
   catch {
-    $statusCode = "unknown"
-    if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
-      $statusCode = [int]$_.Exception.Response.StatusCode
-    }
-    throw "[FAIL] login via gateway failed (HTTP $statusCode). Ensure auth/member are running with shared SQL configuration and credentials are seeded."
+    Write-Host "[WARN] login pre-warm request failed. continue to formal login."
   }
+
+  $loginResponse = $null
+  $maxLoginAttempts = 2
+  for ($attempt = 1; $attempt -le $maxLoginAttempts; $attempt++) {
+    try {
+      $loginResponse = Invoke-Login -Uri $loginUri -LoginIdValue $LoginId -PasswordValue $Password
+      break
+    }
+    catch {
+      $statusCode = "unknown"
+      if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+        $statusCode = [int]$_.Exception.Response.StatusCode
+      }
+      if ($statusCode -eq 504 -and $attempt -lt $maxLoginAttempts) {
+        Write-Host "[WARN] login via gateway returned 504. retrying once..."
+        Start-Sleep -Milliseconds 400
+        continue
+      }
+      throw "[FAIL] login via gateway failed (HTTP $statusCode). Ensure auth/member are running with shared SQL configuration and credentials are seeded."
+    }
+  }
+
+  try {
+    if (-not $loginResponse) {
+      throw "login response is empty."
+    }
+  }
+  catch {
+    throw "[FAIL] login via gateway failed after retry."
+  }  
 
   if (-not $loginResponse.accessToken) {
     throw "[FAIL] login succeeded but accessToken is empty."

--- a/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/GatewayRouteConfiguration.java
+++ b/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/GatewayRouteConfiguration.java
@@ -27,10 +27,13 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
 @Configuration
 public class GatewayRouteConfiguration {
+  private static final Logger log = LoggerFactory.getLogger(GatewayRouteConfiguration.class);
   @Bean
   public GatewayPolicyDocument gatewayPolicy(GatewayPolicyLoader loader) {
     return loader.load();
@@ -58,6 +61,8 @@ public class GatewayRouteConfiguration {
     var routes = builder.routes();
 
     for (ResolvedRoutePolicy route : resolver.resolve(policy)) {
+      log.info("Resolved gateway route id={} path={} target={} authRequired={} rateLimitRps={}",
+          route.id(), route.path(), route.target(), route.authRequired(), route.rateLimitRps());
       routes.route(route.id(), predicate -> {
         var routePredicate = predicate.path(route.path());
         if (!route.methods().isEmpty()) {
@@ -66,11 +71,13 @@ public class GatewayRouteConfiguration {
 
         return routePredicate
             .filters(filters -> {
-              int replenishRate = Math.max(1, route.rateLimitRps());
-              int burstCapacity = Math.max(replenishRate, replenishRate * 2);
-              filters.requestRateLimiter(config ->
-                  config.setRateLimiter(new RedisRateLimiter(replenishRate, burstCapacity)).setKeyResolver(keyResolver)
-              );
+              if (route.rateLimitRps() > 0) {
+                int replenishRate = route.rateLimitRps();
+                int burstCapacity = Math.max(replenishRate, replenishRate * 2);
+                filters.requestRateLimiter(config ->
+                    config.setRateLimiter(new RedisRateLimiter(replenishRate, burstCapacity)).setKeyResolver(keyResolver)
+                );
+              }
 
               if (route.retry().isEnabled() && route.retry().getAttempts() > 0) {
                 filters.retry(config -> config.setRetries(route.retry().getAttempts()));

--- a/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/auth/GatewayResilienceConfiguration.java
+++ b/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/auth/GatewayResilienceConfiguration.java
@@ -3,6 +3,11 @@ package kr.co.computermate.scmrft.gateway.auth;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import java.time.Duration;
+import kr.co.computermate.scmrft.gateway.policy.GatewayPolicyDocument;
+import kr.co.computermate.scmrft.gateway.policy.GatewayRoutePolicyResolver;
+import kr.co.computermate.scmrft.gateway.policy.GatewayRoutePolicyResolver.ResolvedRoutePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.circuitbreaker.resilience4j.ReactiveResilience4JCircuitBreakerFactory;
 import org.springframework.cloud.circuitbreaker.resilience4j.Resilience4JConfigBuilder;
@@ -12,14 +17,18 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class GatewayResilienceConfiguration {
+  private static final Logger log = LoggerFactory.getLogger(GatewayResilienceConfiguration.class);
+
   @Bean
-  public Customizer<ReactiveResilience4JCircuitBreakerFactory> authVerifyCircuitBreakerCustomizer(
+  public Customizer<ReactiveResilience4JCircuitBreakerFactory> gatewayCircuitBreakerCustomizer(
       @Value("${gateway.auth.verify-timeout-ms:1500}") long verifyTimeoutMs,
       @Value("${gateway.auth.circuit-breaker.sliding-window-size:20}") int slidingWindowSize,
       @Value("${gateway.auth.circuit-breaker.minimum-number-of-calls:10}") int minimumNumberOfCalls,
       @Value("${gateway.auth.circuit-breaker.failure-rate-threshold:50}") float failureRateThreshold,
       @Value("${gateway.auth.circuit-breaker.wait-duration-in-open-state-ms:10000}") long waitDurationInOpenStateMs,
-      @Value("${gateway.auth.circuit-breaker.permitted-number-of-calls-in-half-open-state:3}") int permittedHalfOpenCalls
+      @Value("${gateway.auth.circuit-breaker.permitted-number-of-calls-in-half-open-state:3}") int permittedHalfOpenCalls,
+      GatewayPolicyDocument policy,
+      GatewayRoutePolicyResolver policyResolver
   ) {
     int windowSize = Math.max(2, slidingWindowSize);
     int minCalls = Math.max(1, minimumNumberOfCalls);
@@ -27,19 +36,60 @@ public class GatewayResilienceConfiguration {
     long waitMs = Math.max(100L, waitDurationInOpenStateMs);
     int halfOpenCalls = Math.max(1, permittedHalfOpenCalls);
 
-    return factory -> factory.configure(builder -> new Resilience4JConfigBuilder("authVerify")
-        .timeLimiterConfig(TimeLimiterConfig.custom()
-            .timeoutDuration(Duration.ofMillis(timeoutMs))
-            .build())
-        .circuitBreakerConfig(CircuitBreakerConfig.custom()
-            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
-            .slidingWindowSize(windowSize)
-            .minimumNumberOfCalls(minCalls)
-            .failureRateThreshold(failureRateThreshold)
-            .waitDurationInOpenState(Duration.ofMillis(waitMs))
-            .permittedNumberOfCallsInHalfOpenState(halfOpenCalls)
-            .build())
-        .build(), "authVerify");
+    return factory -> {
+      factory.configure(builder -> new Resilience4JConfigBuilder("authVerify")
+          .timeLimiterConfig(TimeLimiterConfig.custom()
+              .timeoutDuration(Duration.ofMillis(timeoutMs))
+              .build())
+          .circuitBreakerConfig(CircuitBreakerConfig.custom()
+              .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+              .slidingWindowSize(windowSize)
+              .minimumNumberOfCalls(minCalls)
+              .failureRateThreshold(failureRateThreshold)
+              .waitDurationInOpenState(Duration.ofMillis(waitMs))
+              .permittedNumberOfCallsInHalfOpenState(halfOpenCalls)
+              .build())
+          .build(), "authVerify");
+
+      for (ResolvedRoutePolicy route : policyResolver.resolve(policy)) {
+        if (!route.circuitBreaker().isEnabled()) {
+          continue;
+        }
+        String breakerName = "cb-" + route.id();
+        long routeTimeoutMs = Math.max(3000L, route.requestTimeoutMs());
+        long routeWaitMs = Math.max(100L, route.circuitBreaker().getWaitDurationInOpenStateMs());
+        float routeFailureThreshold = clampPercentage(route.circuitBreaker().getFailureRateThreshold());
+        float routeSlowCallThreshold = clampPercentage(route.circuitBreaker().getSlowCallRateThreshold());
+
+        factory.configure(builder -> new Resilience4JConfigBuilder(breakerName)
+            .timeLimiterConfig(TimeLimiterConfig.custom()
+                .timeoutDuration(Duration.ofMillis(routeTimeoutMs))
+                .build())
+            .circuitBreakerConfig(CircuitBreakerConfig.custom()
+                .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                .slidingWindowSize(20)
+                .minimumNumberOfCalls(10)
+                .failureRateThreshold(routeFailureThreshold)
+                .slowCallRateThreshold(routeSlowCallThreshold)
+                .waitDurationInOpenState(Duration.ofMillis(routeWaitMs))
+                .permittedNumberOfCallsInHalfOpenState(3)
+                .build())
+            .build(), breakerName);
+
+        log.info("Configured route circuit-breaker: name={} timeoutMs={} failureRate={} slowCallRate={} waitOpenMs={}",
+            breakerName, routeTimeoutMs, routeFailureThreshold, routeSlowCallThreshold, routeWaitMs);
+      }
+    };
+  }
+
+  private float clampPercentage(int value) {
+    if (value < 1) {
+      return 1.0f;
+    }
+    if (value > 100) {
+      return 100.0f;
+    }
+    return (float) value;
   }
 }
 

--- a/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/policy/GatewayPolicyLoader.java
+++ b/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/policy/GatewayPolicyLoader.java
@@ -11,9 +11,12 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component
 public class GatewayPolicyLoader {
+  private static final Logger log = LoggerFactory.getLogger(GatewayPolicyLoader.class);
   private static final String DEFAULT_REPO_POLICY_PATH = "infra/gateway/policies/cutover-isolation.yaml";
   private static final String DEFAULT_CLASSPATH_POLICY_PATH = "policy/cutover-isolation.yaml";
 
@@ -39,6 +42,7 @@ public class GatewayPolicyLoader {
         try (InputStream is = Files.newInputStream(candidate)) {
           GatewayPolicyDocument document = yamlMapper.readValue(is, GatewayPolicyDocument.class);
           document.normalize();
+          log.info("Loaded gateway policy from file: {} (name={}, routes={})", candidate, document.getName(), document.getRoutes().size());
           return document;
         }
         catch (IOException e) {
@@ -54,6 +58,7 @@ public class GatewayPolicyLoader {
     try (InputStream is = resource.getInputStream()) {
       GatewayPolicyDocument document = yamlMapper.readValue(is, GatewayPolicyDocument.class);
       document.normalize();
+      log.info("Loaded gateway policy from classpath: {} (name={}, routes={})", DEFAULT_CLASSPATH_POLICY_PATH, document.getName(), document.getRoutes().size());
       return document;
     }
     catch (IOException e) {

--- a/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/policy/GatewayRoutePolicyResolver.java
+++ b/services/gateway/src/main/java/kr/co/computermate/scmrft/gateway/policy/GatewayRoutePolicyResolver.java
@@ -11,7 +11,10 @@ public class GatewayRoutePolicyResolver {
   public List<ResolvedRoutePolicy> resolve(GatewayPolicyDocument document) {
     List<ResolvedRoutePolicy> policies = new ArrayList<>();
     GatewayPolicyDocument.Defaults defaults = document.getDefaults();
-    int globalRateLimit = Math.max(1, document.getTrafficControl().getGlobalRateLimit().getRequestsPerSecond());
+    GatewayPolicyDocument.GlobalRateLimit globalRateLimitConfig = document.getTrafficControl().getGlobalRateLimit();
+    int globalRateLimit = globalRateLimitConfig.isEnabled()
+        ? Math.max(1, globalRateLimitConfig.getRequestsPerSecond())
+        : 0;
 
     for (GatewayPolicyDocument.RouteRule route : document.getRoutes()) {
       if (route.getMethodPolicies().isEmpty()) {
@@ -65,9 +68,9 @@ public class GatewayRoutePolicyResolver {
         methodPolicy == null ? null : methodPolicy.getCircuitBreaker()
     );
 
-    int rateLimitRps = pickInt(
+    int rateLimitRps = pickRateLimit(
         methodPolicy == null ? null : methodPolicy.getRateLimitRps(),
-        route.getRateLimitRps() > 0 ? route.getRateLimitRps() : null,
+        route.getRateLimitRps(),
         globalRateLimit
     );
 
@@ -96,6 +99,16 @@ public class GatewayRoutePolicyResolver {
       return routeValue;
     }
     return Math.max(1, defaultValue);
+  }
+
+  private int pickRateLimit(Integer methodValue, int routeValue, int defaultValue) {
+    if (methodValue != null) {
+      return Math.max(0, methodValue);
+    }
+    if (routeValue > 0) {
+      return routeValue;
+    }
+    return Math.max(0, defaultValue);
   }
 
   private GatewayPolicyDocument.Retry mergeRetry(

--- a/services/gateway/src/test/java/kr/co/computermate/scmrft/gateway/policy/GatewayRoutePolicyResolverTests.java
+++ b/services/gateway/src/test/java/kr/co/computermate/scmrft/gateway/policy/GatewayRoutePolicyResolverTests.java
@@ -82,4 +82,23 @@ class GatewayRoutePolicyResolverTests {
     assertThat(resolved.stream().filter(item -> item.id().equals("member")).findFirst().orElseThrow().authRequired())
         .isTrue();
   }
+
+  @Test
+  void disablesRateLimitWhenGlobalRateLimitIsDisabledAndRouteDoesNotOverride() {
+    GatewayPolicyDocument document = new GatewayPolicyDocument();
+    GatewayPolicyDocument.GlobalRateLimit globalRateLimit = new GatewayPolicyDocument.GlobalRateLimit();
+    globalRateLimit.setEnabled(false);
+    document.getTrafficControl().setGlobalRateLimit(globalRateLimit);
+
+    GatewayPolicyDocument.RouteRule authRoute = new GatewayPolicyDocument.RouteRule();
+    authRoute.setId("auth");
+    authRoute.setPath("/api/auth/**");
+    authRoute.setTarget("http://auth:8081");
+    document.setRoutes(List.of(authRoute));
+
+    List<GatewayRoutePolicyResolver.ResolvedRoutePolicy> resolved = resolver.resolve(document);
+
+    assertThat(resolved).hasSize(1);
+    assertThat(resolved.getFirst().rateLimitRps()).isZero();
+  }
 }


### PR DESCRIPTION
## 배경/목표
- SCM-217: 리허설 R1 구간에서 간헐적 `gateway -> auth` 504(1s time limiter)로 smoke 실패가 발생
- 로컬 E2E 안정화와 route별 resilience 정책 적용을 동시에 반영

## 변경 요약
- `infra/gateway/policies/local-auth-member-e2e.yaml`
  - auth/member route `circuitBreaker.enabled=false`
  - local E2E용 global rate-limit/emergency-stop 비활성화
- `scripts/smoke-gateway-auth-member-e2e.ps1`
  - login pre-warm 1회 추가
  - login 504 발생 시 1회 재시도 추가
- `scripts/ci-run-gate.ps1`
  - gateway E2E smoke 실패 시 1회 재시도 추가
- `services/gateway/.../GatewayResilienceConfiguration.java`
  - 정책 기반 route CB(`cb-{routeId}`) 동적 구성
  - time-limiter를 `max(3000ms, requestTimeoutMs)`로 연동
- `services/gateway/.../GatewayRouteConfiguration.java`
  - route rate-limit 0 허용
- policy loader/resolver 및 테스트 보강
- `doc/QnA_보고서.md` Q85 반영

## 게이트 결과(로컬)
- build: PASS
- unit-integration-test: PASS
- contract-test: PASS
- smoke-test (gateway E2E 포함): PASS
- migration-dry-run: PASS

## 재현/검증 포인트
- health: `8081/8082/18080` 모두 200
- smoke E2E: login/verify/member 조회/401 시나리오 PASS

## 리스크/롤백
- 리스크: local E2E policy 완화가 운영 정책과 혼동될 수 있음
- 롤백: 본 PR revert 후 기존 smoke 동작 복귀

Closes #26