### PR TITLE
feat(scm-216): add measured R1 outputs and SQL fallback

### DIFF
--- a/migration/reports/R1-SCM-216-20260304-R1-auth.out.txt
+++ b/migration/reports/R1-SCM-216-20260304-R1-auth.out.txt
@@ -1,0 +1,12 @@
+﻿
+domain legacy_count target_count count_mismatch
+------ ------------ ------------ --------------
+auth              0            2              2
+auth                                           
+                                               
+                                               
+auth                                           
+auth                                           
+
+
+

--- a/migration/reports/R1-SCM-216-20260304-R1-board.out.txt
+++ b/migration/reports/R1-SCM-216-20260304-R1-board.out.txt
@@ -1,0 +1,9 @@
+﻿
+domain legacy_count target_count count_mismatch
+------ ------------ ------------ --------------
+board             0            0              0
+board                                          
+board                                          
+
+
+

--- a/migration/reports/R1-SCM-216-20260304-R1-file.out.txt
+++ b/migration/reports/R1-SCM-216-20260304-R1-file.out.txt
@@ -1,0 +1,9 @@
+﻿
+domain legacy_count target_count count_mismatch
+------ ------------ ------------ --------------
+file              0            0              0
+file                                           
+file                                           
+
+
+

--- a/migration/reports/R1-SCM-216-20260304-R1-inventory.out.txt
+++ b/migration/reports/R1-SCM-216-20260304-R1-inventory.out.txt
@@ -1,0 +1,11 @@
+﻿
+domain    metric                legacy_count target_count count_mismatch
+------    ------                ------------ ------------ --------------
+inventory inventory_balances               0            0              0
+inventory inventory_movements              0            0              0
+inventory balance_quantity_sum                                          
+inventory movement_quantity_sum                                         
+inventory                                                               
+
+
+

--- a/migration/reports/R1-SCM-216-20260304-R1-member.out.txt
+++ b/migration/reports/R1-SCM-216-20260304-R1-member.out.txt
@@ -1,0 +1,14 @@
+﻿
+domain legacy_count target_count count_mismatch
+------ ------------ ------------ --------------
+member            0            3              3
+member                                         
+                                               
+                                               
+                                               
+member                                         
+member                                         
+member                                         
+
+
+

--- a/migration/reports/R1-SCM-216-20260304-R1-order-lot.out.txt
+++ b/migration/reports/R1-SCM-216-20260304-R1-order-lot.out.txt
@@ -1,0 +1,10 @@
+﻿
+domain    metric     legacy_count target_count count_mismatch
+------    ------     ------------ ------------ --------------
+order-lot orders                0            0              0
+order-lot order_lots            0            0              0
+order-lot                                                    
+order-lot                                                    
+
+
+

--- a/migration/reports/R1-SCM-216-20260304-R1-quality-doc.out.txt
+++ b/migration/reports/R1-SCM-216-20260304-R1-quality-doc.out.txt
@@ -1,0 +1,10 @@
+﻿
+domain      metric                legacy_count target_count count_mismatch
+------      ------                ------------ ------------ --------------
+quality-doc quality_documents                0            0              0
+quality-doc quality_document_acks            0            0              0
+quality-doc                                                               
+quality-doc                                                               
+
+
+

--- a/migration/reports/R1-SCM-216-20260304-R1-report.out.txt
+++ b/migration/reports/R1-SCM-216-20260304-R1-report.out.txt
@@ -1,0 +1,9 @@
+﻿
+domain legacy_count target_count count_mismatch
+------ ------------ ------------ --------------
+report            0            0              0
+report                                         
+report                                         
+
+
+

--- a/migration/reports/SCM-216-20260304-R1-execution.md
+++ b/migration/reports/SCM-216-20260304-R1-execution.md
@@ -1,0 +1,165 @@
+﻿# SCM-213 R1 Execution Result
+
+- RunId: SCM-216-20260304-R1
+- GeneratedAt: 2026-03-04 14:26:34
+- SqlDir: C:\Users\CMN-091\projects\SCM_RFT_wt_216\migration\sql\r1-validation
+- SqlExecution: EXECUTED
+
+## Domain Execution Order
+auth -> member -> file -> inventory -> report -> order-lot -> board -> quality-doc
+
+## Raw Outputs
+| Domain | Output File |
+|---|---|
+| auth | migration\reports\R1-SCM-216-20260304-R1-auth.out.txt |
+| member | migration\reports\R1-SCM-216-20260304-R1-member.out.txt |
+| file | migration\reports\R1-SCM-216-20260304-R1-file.out.txt |
+| inventory | migration\reports\R1-SCM-216-20260304-R1-inventory.out.txt |
+| report | migration\reports\R1-SCM-216-20260304-R1-report.out.txt |
+| order-lot | migration\reports\R1-SCM-216-20260304-R1-order-lot.out.txt |
+| board | migration\reports\R1-SCM-216-20260304-R1-board.out.txt |
+| quality-doc | migration\reports\R1-SCM-216-20260304-R1-quality-doc.out.txt |
+
+## R1 Thresholds
+- count mismatch = 0
+- sum delta <= 0.1%
+- sample mismatch = 0/200
+- status delta <= 1.0%p
+
+## Template Appendix
+
+# SCM-213 R1 Validation Report Template
+
+## 1) Run Metadata
+- RunId: `SCM-216-20260304-R1`
+- RunId 규칙:
+  - Prefix: `R1-`
+  - Timestamp: `yyyyMMdd-HHmmss` (KST 기준)
+  - Suffix: `DEV|STG|PRD-REHEARSAL`
+  - 예시: `R1-20260226-153000-STG`
+- 실행환경:
+  - Legacy DB: `<MES_HI_LEGACY>`
+  - Target DB: `<MES_HI>`
+  - Host/Container: `<hostname or container>`
+  - Tool: `sqlcmd` / `SSMS`
+- 실행자:
+  - Dev: `<name>`
+  - Codex: `<name>`
+- 실행시간:
+  - StartedAt: `2026-03-04 14:26:34`
+  - EndedAt: `2026-03-04 14:26:34`
+  - Duration(min): `<number>`
+
+## 2) SQL 실행 파일 경로
+- `migration/sql/r1-validation/01-auth-validation.sql`
+- `migration/sql/r1-validation/02-member-validation.sql`
+- `migration/sql/r1-validation/03-file-validation.sql`
+- `migration/sql/r1-validation/04-inventory-validation.sql`
+- `migration/sql/r1-validation/05-report-validation.sql`
+- `migration/sql/r1-validation/06-order-lot-validation.sql`
+- `migration/sql/r1-validation/07-board-validation.sql`
+- `migration/sql/r1-validation/08-quality-doc-validation.sql`
+
+## 3) 결과 요약
+| 항목 | 값 | 판정 |
+|---|---:|---|
+| 실행 도메인 수 | `<8>` | `<PASS/FAIL>` |
+| count mismatch 도메인 수 | `<n>` | `<PASS/FAIL>` |
+| sum 임계치 초과 도메인 수 | `<n>` | `<PASS/FAIL>` |
+| sample mismatch 초과 도메인 수 | `<n>` | `<PASS/FAIL>` |
+| status delta 초과 도메인 수 | `<n>` | `<PASS/FAIL>` |
+| 최종 판정 | `<GO/NO-GO>` | `<확정>` |
+
+## 4) 도메인별 결과
+
+### 4.1 auth
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(failed_count) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(password_algo) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.2 member
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(active_count) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(status) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.3 file
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(DATALENGTH(storage_path)) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(domain_key) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.4 inventory
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count(balances/movements) |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(quantity) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200, movements) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(movement_type) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.5 report
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(failed_count) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(status) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.6 order-lot
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count(orders/lots) |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(order_lots.quantity) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200, lots) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(orders.status) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.7 board
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(notice_count) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(status) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+### 4.8 quality-doc
+| 검증 항목 | legacy | target | 비교값 | 임계치 | 판정 | 증적 경로 |
+|---|---:|---:|---:|---:|---|---|
+| count(documents/acks) |  |  | `mismatch=` | `0` |  | `migration/reports/<file>` |
+| sum(ack_count) |  |  | `delta%=` | `<=0.1%` |  | `migration/reports/<file>` |
+| sample(200, documents) |  |  | `mismatch=/200` | `0/200` |  | `migration/reports/<file>` |
+| status(documents.status) |  |  | `max_delta_pp=` | `<=1.0%p` |  | `migration/reports/<file>` |
+
+## 5) 이슈 / 조치
+| Domain | 이슈 유형(count/sum/sample/status) | 증상 | 원인 | 조치 내용 | 재검증 결과 |
+|---|---|---|---|---|---|
+|  |  |  |  |  |  |
+
+## 6) Go/No-Go 초안
+| 기준 | 결과 | 판정 |
+|---|---|---|
+| count mismatch = 0 |  |  |
+| sum delta <= 0.1% |  |  |
+| sample mismatch = 0/200 |  |  |
+| status delta <= 1.0%p |  |  |
+| 종합 |  | `<GO / NO-GO>` |
+
+## 7) R1 판정 체크 규칙 (고정)
+- `count mismatch = 0` 이 아니면 `NO-GO`.
+- `sum delta > 0.1%` 인 도메인이 1개라도 있으면 `NO-GO`.
+- `sample mismatch > 0/200` 인 도메인이 1개라도 있으면 `NO-GO`.
+- `status delta > 1.0%p` 인 도메인이 1개라도 있으면 `NO-GO`.
+
+## 8) 부록 (실행 로그 / 커맨드)
+```powershell
+# 예시: sqlcmd 실행
+# sqlcmd -S <server> -U <user> -P <password> -i migration/sql/r1-validation/01-auth-validation.sql -o migration/reports/R1-auth-output.txt
+```
+
+

--- a/migration/scripts/run-r1-validation.ps1
+++ b/migration/scripts/run-r1-validation.ps1
@@ -43,20 +43,15 @@ $domains = @(
 
 $outputs = @()
 
-if (-not $SkipSqlExecution) {
+function Invoke-ValidationSql {
+  param(
+    [Parameter(Mandatory = $true)][string]$SqlPath,
+    [Parameter(Mandatory = $true)][string]$OutPath
+  )
+
   $sqlcmd = Get-Command sqlcmd -ErrorAction SilentlyContinue
-  if (-not $sqlcmd) {
-    throw "sqlcmd is required. Install SQL Server command line tools or run with -SkipSqlExecution."
-  }
-
-  foreach ($item in $domains) {
-    $sqlPath = Join-Path $resolvedSqlDir $item.File
-    if (-not (Test-Path $sqlPath)) {
-      throw "SQL file not found: $sqlPath"
-    }
-
-    $outPath = Join-Path $resolvedReportDir ("R1-{0}-{1}.out.txt" -f $RunId, $item.Key)
-    $args = @("-S", $Server, "-d", $Database, "-i", $sqlPath, "-o", $outPath, "-b", "-I")
+  if ($sqlcmd) {
+    $args = @("-S", $Server, "-d", $Database, "-i", $SqlPath, "-o", $OutPath, "-b", "-I")
     if ($UseTrustedConnection) {
       $args += "-E"
     }
@@ -67,11 +62,51 @@ if (-not $SkipSqlExecution) {
       $args += @("-U", $User, "-P", $Password)
     }
 
-    Write-Host ("[INFO] executing: {0}" -f $item.File)
     & sqlcmd @args
     if ($LASTEXITCODE -ne 0) {
-      throw ("sqlcmd failed for {0}" -f $item.File)
+      throw ("sqlcmd failed for {0}" -f (Split-Path $SqlPath -Leaf))
     }
+    return
+  }
+
+  $invokeSqlcmd = Get-Command Invoke-Sqlcmd -ErrorAction SilentlyContinue
+  if (-not $invokeSqlcmd) {
+    Import-Module SqlServer -ErrorAction SilentlyContinue
+    $invokeSqlcmd = Get-Command Invoke-Sqlcmd -ErrorAction SilentlyContinue
+  }
+  if (-not $invokeSqlcmd) {
+    throw "Neither sqlcmd nor Invoke-Sqlcmd is available."
+  }
+
+  $conn = if ($UseTrustedConnection) {
+    "Server=$Server;Database=$Database;Trusted_Connection=True;TrustServerCertificate=True;Encrypt=False;"
+  }
+  else {
+    if ([string]::IsNullOrWhiteSpace($Password)) {
+      throw "Password is required when -UseTrustedConnection is not set."
+    }
+    "Server=$Server;Database=$Database;User ID=$User;Password=$Password;TrustServerCertificate=True;Encrypt=False;"
+  }
+
+  $result = Invoke-Sqlcmd -ConnectionString $conn -InputFile $SqlPath -QueryTimeout 600 -ErrorAction Stop
+  if ($null -eq $result) {
+    "" | Set-Content -Path $OutPath -Encoding UTF8
+  }
+  else {
+    $result | Format-Table -AutoSize | Out-String -Width 4096 | Set-Content -Path $OutPath -Encoding UTF8
+  }
+}
+
+if (-not $SkipSqlExecution) {
+  foreach ($item in $domains) {
+    $sqlPath = Join-Path $resolvedSqlDir $item.File
+    if (-not (Test-Path $sqlPath)) {
+      throw "SQL file not found: $sqlPath"
+    }
+
+    $outPath = Join-Path $resolvedReportDir ("R1-{0}-{1}.out.txt" -f $RunId, $item.Key)
+    Write-Host ("[INFO] executing: {0}" -f $item.File)
+    Invoke-ValidationSql -SqlPath $sqlPath -OutPath $outPath
     $outputs += [pscustomobject]@{
       Domain = $item.Key
       OutputPath = $outPath


### PR DESCRIPTION
## 배경/목표
SCM-213 실측 실행 결과를 SCM-216 브랜치에 반영하고, sqlcmd 미설치 환경에서도 실행 가능한 fallback 경로를 추가합니다.

## 변경 요약
- `migration/scripts/run-r1-validation.ps1`
  - `sqlcmd` 우선 실행
  - 미설치 시 `Invoke-Sqlcmd` fallback 실행 지원
- `migration/reports/SCM-216-20260304-R1-execution.md`
- `migration/reports/R1-SCM-216-20260304-R1-*.out.txt` (8개 도메인)

## 기준/검증
- 로컬 5게이트 재실행 완료(build, unit-integration-test, contract-test, smoke-test, migration-dry-run)
- 상세 로그: `runbooks/evidence/SCM-216-20260304-PR/`