### PR TITLE
docs(scm-227): append rollback R2/R3 measured evidence

### DIFF
--- a/doc/QnA_보고서.md
+++ b/doc/QnA_보고서.md
@@ -1403,3 +1403,25 @@ Java 21로 업그레이드(현재 17) 및 버전 고정 정책 적용
   - Signoff 반영:
     - `runbooks/go-nogo-signoff.md`의 Rollback time 항목을 PASS 실측값으로 갱신
     - rollback-time pending 체크를 완료로 전환
+
+### Q98. SCM-226 R2/R3 롤백 시간 실측 누적
+- 사용자 프롬프트:
+  - "진행해줘"
+- Codex 답변(결과):
+  - 추적 단위 생성:
+    - Issue: `#36` (`SCM-227: add rollback-time R2/R3 measured evidence`)
+    - Branch: `feature/scm-227-rollback-r2-r3-evidence`
+  - 실측 실행:
+    - `powershell -File .\\scripts\\scm226-measure-rollback-time.ps1 -RunId SCM-226-20260305-R2 -Staging -ThresholdMinutes 20`
+    - `powershell -File .\\scripts\\scm226-measure-rollback-time.ps1 -RunId SCM-226-20260305-R3 -Staging -ThresholdMinutes 20`
+  - 결과:
+    - R2: `elapsedMinutes=0.05`, `verdict=PASS`
+    - R3: `elapsedMinutes=0.05`, `verdict=PASS`
+    - 증적:
+      - `runbooks/evidence/SCM-226-20260305-R2/rollback-time-summary.md`
+      - `runbooks/evidence/SCM-226-20260305-R3/rollback-time-summary.md`
+  - 문서 반영:
+    - `runbooks/go-nogo-signoff.md`
+      - R1~R3 rollback-time evidence root 누적
+      - rollback metric을 다회차 실측값으로 갱신
+      - `Rollback Measurement History` 섹션 추가

--- a/runbooks/go-nogo-signoff.md
+++ b/runbooks/go-nogo-signoff.md
@@ -10,6 +10,8 @@
   - `runbooks/evidence/SCM-225-20260305-P0/`
   - `migration/reports/SCM-225-20260305-R*-measured.md`
   - `runbooks/evidence/SCM-226-20260305-R1/rollback-time-summary.md`
+  - `runbooks/evidence/SCM-226-20260305-R2/rollback-time-summary.md`
+  - `runbooks/evidence/SCM-226-20260305-R3/rollback-time-summary.md`
 
 ## 2) Required Inputs
 - [x] `runbooks/evidence/SCM-225-20260305-GATES/gate-build.log`
@@ -33,7 +35,7 @@
 | RabbitMQ backlog | `http://localhost:35672/api/queues` (`scm_stage`) | `ready<=1000, unacked<=500` | `ready=0, unacked=0` | PASS |
 | DB deadlock/timeout | `Invoke-Sqlcmd` system_health last 10m | `deadlock=0, timeout<=3` | `0 / 0` | PASS |
 | Data consistency | `SCM-225-20260305-R1~R3-measured.md` | `count=0, sum<=0.1%, sample=0/200, status<=1.0%p` | `3 runs, 8/8 PASS` | PASS |
-| Rollback time | `runbooks/evidence/SCM-226-20260305-R1/rollback-time-summary.md` | `<=20m` | `0.05m` | PASS |
+| Rollback time | `SCM-226-20260305-R1/R2/R3 rollback-time-summary.md` | `<=20m` | `R1=0.05m, R2=0.05m, R3=0.05m (max=0.05m)` | PASS |
 | Auth failure rate | auth route summary (`0/6`) | `<=3.0%` | `0.00%` | PASS |
 
 ## 4) Order-Lot Strict Metrics
@@ -55,6 +57,15 @@
 
 **Decision:** `GO (R1~R3 rehearsal scope)`  
 **Follow-up:** run SCM-226 measurement for each future rehearsal cycle and append evidence links.
+
+## 5.1 Rollback Measurement History
+| RunId | ElapsedMinutes | ThresholdMinutes | Verdict | Evidence |
+|---|---:|---:|---|---|
+| SCM-226-20260305-R1 | 0.05 | 20 | PASS | `runbooks/evidence/SCM-226-20260305-R1/rollback-time-summary.md` |
+| SCM-226-20260305-R2 | 0.05 | 20 | PASS | `runbooks/evidence/SCM-226-20260305-R2/rollback-time-summary.md` |
+| SCM-226-20260305-R3 | 0.05 | 20 | PASS | `runbooks/evidence/SCM-226-20260305-R3/rollback-time-summary.md` |
+
+Note: health probe result in each summary depends on service runtime state at measurement time and is not part of rollback-time threshold (`<=20m`).
 
 ## 6) Sign-off
 


### PR DESCRIPTION
﻿## Background/Goal
Accumulate rollback-time measured evidence for R2/R3 and reflect in signoff.

## Scope
- Update signoff with R1~R3 rollback measurement history
- Update QnA execution history
- Use measured evidence already generated under runbooks/evidence

## Evidence
- R2 summary: `runbooks/evidence/SCM-226-20260305-R2/rollback-time-summary.md`
- R3 summary: `runbooks/evidence/SCM-226-20260305-R3/rollback-time-summary.md`

## Measured Result
- R2: elapsedMinutes=0.05, PASS
- R3: elapsedMinutes=0.05, PASS

## Updated Files
- `runbooks/go-nogo-signoff.md`
- `doc/QnA_보고서.md`

Closes #36
