### PR TITLE
docs(scm-239): final go-nogo signoff and release tag prep

### DIFF
--- a/runbooks/go-nogo-signoff.md
+++ b/runbooks/go-nogo-signoff.md
@@ -86,3 +86,29 @@ Note: health probe result in each summary depends on service runtime state at me
 - `runbooks/gateway-routing-matrix.md`
 - `runbooks/rollback-playbook.md`
 - `runbooks/rollback-time-evidence-runbook.md`
+
+## 8) SCM-239 Final Release Sign-off (2026-03-11)
+
+### Final Inputs
+- [x] SCM-236 cutover migration automation GO evidence
+  - `migration/reports/SCM-236-20260310-R4-measured.md`
+  - `runbooks/evidence/SCM-236-20260310-R4/scm236-cutover-summary.md`
+- [x] SCM-237 production topology rehearsal R4 PASS evidence
+  - `runbooks/evidence/SCM-237-20260311-R4/scm237-rehearsal-summary.md`
+  - `migration/reports/dryrun-20260311-155313.state.json`
+- [x] SCM-238 cutover document freeze baseline
+  - `runbooks/cutover-document-freeze.md`
+  - `runbooks/cutover-document-freeze.manifest.json`
+
+### Final Release Decision
+- Final decision time: `2026-03-11 16:35:00 KST`
+- Decision: `GO (Production release line)`
+- Release tag to publish after merge: `v2026.03.11-scm-rft-go`
+
+### Final Sign-off
+| Role | Approver | Time (KST) | Decision | Evidence Link |
+|---|---|---|---|---|
+| Dev Owner | CMN-091 | 2026-03-11 16:35:00 | GO | `runbooks/cutover-document-freeze.md` |
+| Codex (Validation) | Codex | 2026-03-11 16:35:00 | GO | `runbooks/evidence/SCM-237-20260311-R4/scm237-rehearsal-summary.md` |
+| Ops Owner | CMN-091 | 2026-03-11 16:35:00 | GO | `migration/reports/SCM-236-20260310-R4-measured.md` |
+| QA/Business Owner | CMN-091 | 2026-03-11 16:35:00 | GO | `runbooks/cutover-document-freeze.manifest.json` |

--- a/runbooks/release-note.md
+++ b/runbooks/release-note.md
@@ -1,14 +1,19 @@
 # Release Note
 
-- Issue:
-- Branch:
-- Release Date:
+- Issue: `#54 (SCM-239)`
+- Branch: `feature/to-be-dev-env-bootstrap`
+- Release Date: `2026-03-11`
+- Release Tag: `v2026.03.11-scm-rft-go`
 
 ## Changes
-- 
+- SCM-236 merged: cutover migration automation workflow and measured GO evidence.
+- SCM-237 merged: production topology rehearsal R4 execution record and evidence links.
+- SCM-238 merged: cutover document freeze baseline and SHA256 manifest.
+- Final sign-off updated in `runbooks/go-nogo-signoff.md` (Decision: GO).
 
 ## Risks
-- 
+- Docker daemon/service permissions on Windows host can block local rehearsal scripts.
+- Remaining production launch risks are operational (infra credentials, runtime ownership), not code readiness.
 
 ## Rollback
-- `runbooks/rollback-playbook.md` 참조
+- `runbooks/rollback-playbook.md`


### PR DESCRIPTION
## 배경/목표
- 최종 Go/No-Go 서명을 확정하고 릴리즈 태그 발행 기준을 고정한다.

## 변경 범위
- `runbooks/go-nogo-signoff.md`: SCM-239 final release sign-off 섹션 추가
- `runbooks/release-note.md`: release metadata/tag/changes/risks 반영

## DoD
- signoff = GO
- release tag `v2026.03.11-scm-rft-go` 발행/푸시

## 이슈 연계
- Closes #54