### PR TITLE
feat(scm-249): implement inventory file report ui

### DIFF
--- a/doc/QnA_보고서.md
+++ b/doc/QnA_보고서.md
@@ -2946,3 +2946,62 @@ Java 21로 업그레이드(현재 17) 및 버전 고정 정책 적용
 - 결과:
   - `SCM-248` UI MVP는 프론트 게이트와 실제 gateway smoke 기준으로 구현 완료
   - 다음 단계는 `SCM-249 Inventory + File + Report UI` 전용 이슈/브랜치로 진입
+
+### Q164. SCM-249 Inventory + File + Report UI MVP 구현 및 실측 검증 완료 (2026-03-13)
+- 사용자 요청 맥락:
+  - `SCM-248 -> SCM-249 -> SCM-250` 프론트 PR 라인 순차 진행
+- 수행 내용:
+  - 이슈/브랜치 생성:
+    - Issue `#76` 생성: `[SCM-249] Inventory + File + Report UI MVP`
+    - 브랜치: `feature/scm-249-inventory-file-report-ui`
+  - 프론트 변경:
+    - `frontend/packages/api-client/src/index.ts`
+      - Inventory 타입/메서드 추가:
+        - `searchInventoryBalances`
+        - `searchInventoryMovements`
+      - File 타입/메서드 추가:
+        - `registerFile`
+        - `getFile`
+      - Report 타입/메서드 추가:
+        - `createReportJob`
+        - `getReportJob`
+    - `frontend/apps/web-portal/src/features/inventory-file-report-panel.tsx` 추가
+      - Inventory balance/movement 조회 UI
+      - File metadata register/detail UI
+      - Report job create/detail UI
+      - 로그인 사용자 힌트를 `requestedByMemberId`에 자동 추적하되 수동 override는 유지
+    - `frontend/apps/web-portal/src/features/inventory-file-report-panel.test.ts` 추가
+      - tracked field 동기화 로직 테스트
+    - `frontend/apps/web-portal/src/App.tsx`
+      - 새 패널 연결
+      - `VITE_INVENTORY_API_BASE_URL`, `VITE_FILE_API_BASE_URL`, `VITE_REPORT_API_BASE_URL` 오버라이드 지원
+      - hero/meta에 도메인 base 정보 확장
+  - 프론트 게이트:
+    - `frontend-build` PASS
+    - `frontend-unit-test` PASS
+    - `frontend-contract-test` PASS
+    - `frontend-e2e-smoke` PASS
+    - `frontend-security-scan` PASS
+  - 실제 백엔드/게이트웨이 검증:
+    - 로컬 cached Gradle + `SCM_FLYWAY_ENABLED=false`로 `inventory`, `file`, `report` 기동
+    - health 확인:
+      - `inventory` `UP` (`8086`)
+      - `file` `UP` (`8087`)
+      - `report` `UP` (`8088`)
+      - `gateway` `UP` (`18080`)
+    - SQL seed + gateway smoke 실행 결과:
+      - login PASS (`memberId=smoke-user`)
+      - inventory balances PASS (`inventoryBalanceCount=1`)
+      - inventory movements PASS (`inventoryMovementCount=1`)
+      - file register PASS (`fileId=be65e81f-f6cb-47e8-9111-8cd57e222b51`)
+      - file detail PASS (`fileDetailId=be65e81f-f6cb-47e8-9111-8cd57e222b51`)
+      - report create PASS (`jobId=29d6fc65-2d6a-4f4a-8d4f-24c43aa12d56`)
+      - report detail PASS (`status=QUEUED`)
+- 산출물/근거:
+  - `runbooks/evidence/SCM-249-inventory.stdout.log`
+  - `runbooks/evidence/SCM-249-file.stdout.log`
+  - `runbooks/evidence/SCM-249-report.stdout.log`
+  - `runbooks/evidence/SCM-249-gateway-smoke-summary.json`
+- 결과:
+  - `SCM-249` UI MVP는 프론트 게이트와 실제 gateway smoke 기준으로 구현 완료
+  - 다음 단계는 `SCM-250` 통합 E2E + 컷오버 UI/런북 연계로 진입

--- a/frontend/apps/web-portal/src/App.tsx
+++ b/frontend/apps/web-portal/src/App.tsx
@@ -3,6 +3,7 @@ import { describePortalScope } from "@scm-rft/ui";
 import { readContractCatalog } from "@scm-rft/api-client";
 import { AuthMemberPanel } from "./features/auth-member-panel";
 import { BoardQualityDocPanel } from "./features/board-qualitydoc-panel";
+import { InventoryFileReportPanel } from "./features/inventory-file-report-panel";
 import { OrderLotPanel } from "./features/order-lot-panel";
 
 const TOKEN_STORAGE_KEY = "scm-rft.access-token";
@@ -23,6 +24,9 @@ export default function App() {
   const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? "";
   const boardApiBaseUrl = import.meta.env.VITE_BOARD_API_BASE_URL ?? apiBaseUrl;
   const qualityDocApiBaseUrl = import.meta.env.VITE_QUALITY_DOC_API_BASE_URL ?? apiBaseUrl;
+  const inventoryApiBaseUrl = import.meta.env.VITE_INVENTORY_API_BASE_URL ?? apiBaseUrl;
+  const fileApiBaseUrl = import.meta.env.VITE_FILE_API_BASE_URL ?? apiBaseUrl;
+  const reportApiBaseUrl = import.meta.env.VITE_REPORT_API_BASE_URL ?? apiBaseUrl;
   const orderLotApiBaseUrl = import.meta.env.VITE_ORDER_LOT_API_BASE_URL ?? apiBaseUrl;
 
   useEffect(() => {
@@ -40,14 +44,18 @@ export default function App() {
         <p className="eyebrow">Frontend Modernization</p>
         <h1>{title}</h1>
         <p className="heroText">
-          The portal now covers Auth, Member, Board, Quality-Doc, and Order-Lot MVP paths so the
-          main P0 workflows can be exercised against the gateway from one surface.
+          The portal now covers Auth, Member, Board, Quality-Doc, Inventory, File, Report, and
+          Order-Lot MVP paths so the main P0 workflows can be exercised against the gateway from
+          one surface.
         </p>
         <div className="heroMeta">
           <span>Contracts: {catalog.contracts.length}</span>
           <span>Auth/Member base: {apiBaseUrl || "(same origin)"}</span>
           <span>Board base: {boardApiBaseUrl || "(same origin)"}</span>
           <span>Quality-Doc base: {qualityDocApiBaseUrl || "(same origin)"}</span>
+          <span>Inventory base: {inventoryApiBaseUrl || "(same origin)"}</span>
+          <span>File base: {fileApiBaseUrl || "(same origin)"}</span>
+          <span>Report base: {reportApiBaseUrl || "(same origin)"}</span>
           <span>Order-Lot base: {orderLotApiBaseUrl || "(same origin)"}</span>
         </div>
       </header>
@@ -62,6 +70,14 @@ export default function App() {
       <BoardQualityDocPanel
         boardApiBaseUrl={boardApiBaseUrl}
         qualityDocApiBaseUrl={qualityDocApiBaseUrl}
+        accessToken={accessToken}
+        memberIdHint={currentMemberId}
+      />
+
+      <InventoryFileReportPanel
+        inventoryApiBaseUrl={inventoryApiBaseUrl}
+        fileApiBaseUrl={fileApiBaseUrl}
+        reportApiBaseUrl={reportApiBaseUrl}
         accessToken={accessToken}
         memberIdHint={currentMemberId}
       />

--- a/frontend/apps/web-portal/src/features/inventory-file-report-panel.test.ts
+++ b/frontend/apps/web-portal/src/features/inventory-file-report-panel.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveTrackedValue } from "./inventory-file-report-panel";
+
+describe("inventory/report tracked value", () => {
+  it("follows the latest member hint when the field still mirrors the previous hint", () => {
+    expect(
+      resolveTrackedValue({
+        currentValue: "smoke-user",
+        nextHint: "smoke-admin",
+        previousHint: "smoke-user"
+      })
+    ).toBe("smoke-admin");
+  });
+
+  it("preserves manual overrides", () => {
+    expect(
+      resolveTrackedValue({
+        currentValue: "manual-requester",
+        nextHint: "smoke-admin",
+        previousHint: "smoke-user"
+      })
+    ).toBe("manual-requester");
+  });
+});

--- a/frontend/apps/web-portal/src/features/inventory-file-report-panel.tsx
+++ b/frontend/apps/web-portal/src/features/inventory-file-report-panel.tsx
@@ -1,0 +1,307 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  createScmApiClient,
+  formatApiError,
+  type FileMetadata,
+  type InventoryBalanceSearchResponse,
+  type InventoryMovementSearchResponse,
+  type ReportJob
+} from "@scm-rft/api-client";
+
+type InventoryFileReportPanelProps = {
+  inventoryApiBaseUrl: string;
+  fileApiBaseUrl: string;
+  reportApiBaseUrl: string;
+  accessToken: string;
+  memberIdHint?: string;
+};
+
+type ResolveTrackedValueArgs = {
+  currentValue: string;
+  nextHint: string;
+  previousHint: string;
+};
+
+export function resolveTrackedValue({
+  currentValue,
+  nextHint,
+  previousHint
+}: ResolveTrackedValueArgs) {
+  if (!nextHint) {
+    return currentValue;
+  }
+
+  if (!currentValue || currentValue === previousHint) {
+    return nextHint;
+  }
+
+  return currentValue;
+}
+
+export function InventoryFileReportPanel({
+  inventoryApiBaseUrl,
+  fileApiBaseUrl,
+  reportApiBaseUrl,
+  accessToken,
+  memberIdHint = ""
+}: InventoryFileReportPanelProps) {
+  const [itemCode, setItemCode] = useState("ITEM-001");
+  const [warehouseCode, setWarehouseCode] = useState("");
+  const [inventoryPage, setInventoryPage] = useState("0");
+  const [inventorySize, setInventorySize] = useState("10");
+  const [movementType, setMovementType] = useState("");
+  const [fileId, setFileId] = useState("");
+  const [domainKey, setDomainKey] = useState("P0:BOARD");
+  const [originalName, setOriginalName] = useState("frontend-proof.txt");
+  const [storagePath, setStoragePath] = useState("frontend/frontend-proof.txt");
+  const [reportType, setReportType] = useState("P0_DAILY");
+  const [requestedByMemberId, setRequestedByMemberId] = useState(memberIdHint);
+  const [jobId, setJobId] = useState("");
+  const [errorText, setErrorText] = useState("");
+  const [balanceResult, setBalanceResult] = useState<InventoryBalanceSearchResponse | null>(null);
+  const [movementResult, setMovementResult] = useState<InventoryMovementSearchResponse | null>(null);
+  const [fileRegisterResult, setFileRegisterResult] = useState<FileMetadata | null>(null);
+  const [fileDetailResult, setFileDetailResult] = useState<FileMetadata | null>(null);
+  const [reportCreateResult, setReportCreateResult] = useState<ReportJob | null>(null);
+  const [reportDetailResult, setReportDetailResult] = useState<ReportJob | null>(null);
+  const previousRequestedByHintRef = useRef(memberIdHint);
+
+  useEffect(() => {
+    setRequestedByMemberId((currentValue) =>
+      resolveTrackedValue({
+        currentValue,
+        nextHint: memberIdHint,
+        previousHint: previousRequestedByHintRef.current
+      })
+    );
+    previousRequestedByHintRef.current = memberIdHint;
+  }, [memberIdHint]);
+
+  async function run<T>(action: () => Promise<T>, onSuccess: (result: T) => void) {
+    setErrorText("");
+    try {
+      const result = await action();
+      onSuccess(result);
+    } catch (error) {
+      setErrorText(formatApiError(error));
+    }
+  }
+
+  function buildInventoryClient() {
+    return createScmApiClient({ baseUrl: inventoryApiBaseUrl, accessToken });
+  }
+
+  function buildFileClient() {
+    return createScmApiClient({ baseUrl: fileApiBaseUrl, accessToken });
+  }
+
+  function buildReportClient() {
+    return createScmApiClient({ baseUrl: reportApiBaseUrl, accessToken });
+  }
+
+  async function handleSearchBalances() {
+    await run(
+      () =>
+        buildInventoryClient().searchInventoryBalances({
+          itemCode,
+          warehouseCode,
+          page: Number(inventoryPage || "0"),
+          size: Number(inventorySize || "10")
+        }),
+      setBalanceResult
+    );
+  }
+
+  async function handleSearchMovements() {
+    await run(
+      () =>
+        buildInventoryClient().searchInventoryMovements({
+          itemCode,
+          warehouseCode,
+          movementType,
+          page: Number(inventoryPage || "0"),
+          size: Number(inventorySize || "10")
+        }),
+      setMovementResult
+    );
+  }
+
+  async function handleRegisterFile() {
+    await run(
+      () =>
+        buildFileClient().registerFile({
+          domainKey,
+          originalName,
+          storagePath
+        }),
+      (result) => {
+        setFileRegisterResult(result);
+        setFileId(result.fileId);
+      }
+    );
+  }
+
+  async function handleGetFile() {
+    await run(() => buildFileClient().getFile(fileId), setFileDetailResult);
+  }
+
+  async function handleCreateReportJob() {
+    await run(
+      () =>
+        buildReportClient().createReportJob({
+          reportType,
+          requestedByMemberId
+        }),
+      (result) => {
+        setReportCreateResult(result);
+        setJobId(result.jobId);
+      }
+    );
+  }
+
+  async function handleGetReportJob() {
+    await run(() => buildReportClient().getReportJob(jobId), setReportDetailResult);
+  }
+
+  return (
+    <section className="panel">
+      <div className="panelHeader">
+        <p className="eyebrow">SCM-249</p>
+        <h2>Inventory + File + Report UI MVP</h2>
+        <p className="panelIntro">
+          Inventory stays read-only, file focuses on metadata registration and lookup, and report
+          covers job create plus status polling to complete the portal-side P0 toolbox.
+        </p>
+      </div>
+
+      <div className="actionGrid">
+        <div className="card">
+          <h3>Inventory Balances</h3>
+          <label>
+            Item Code
+            <input value={itemCode} onChange={(event) => setItemCode(event.target.value)} />
+          </label>
+          <label>
+            Warehouse Code
+            <input
+              value={warehouseCode}
+              onChange={(event) => setWarehouseCode(event.target.value)}
+            />
+          </label>
+          <div className="inlineFields">
+            <label>
+              Page
+              <input
+                value={inventoryPage}
+                onChange={(event) => setInventoryPage(event.target.value)}
+              />
+            </label>
+            <label>
+              Size
+              <input
+                value={inventorySize}
+                onChange={(event) => setInventorySize(event.target.value)}
+              />
+            </label>
+          </div>
+          <button onClick={handleSearchBalances}>Search Balances</button>
+          <ResultBlock title="Inventory Balance Response" value={balanceResult} />
+        </div>
+
+        <div className="card">
+          <h3>Inventory Movements</h3>
+          <label>
+            Movement Type
+            <select value={movementType} onChange={(event) => setMovementType(event.target.value)}>
+              <option value="">ALL</option>
+              <option value="IN">IN</option>
+              <option value="OUT">OUT</option>
+              <option value="ADJUST">ADJUST</option>
+            </select>
+          </label>
+          <p className="hintText">
+            Uses the same `itemCode`, `warehouseCode`, `page`, and `size` inputs as balance search.
+          </p>
+          <button onClick={handleSearchMovements}>Search Movements</button>
+          <ResultBlock title="Inventory Movement Response" value={movementResult} />
+        </div>
+
+        <div className="card">
+          <h3>File Register</h3>
+          <label>
+            Domain Key
+            <input value={domainKey} onChange={(event) => setDomainKey(event.target.value)} />
+          </label>
+          <label>
+            Original Name
+            <input
+              value={originalName}
+              onChange={(event) => setOriginalName(event.target.value)}
+            />
+          </label>
+          <label>
+            Storage Path
+            <input value={storagePath} onChange={(event) => setStoragePath(event.target.value)} />
+          </label>
+          <button onClick={handleRegisterFile}>Register File Metadata</button>
+          <ResultBlock title="File Register Response" value={fileRegisterResult} />
+        </div>
+
+        <div className="card">
+          <h3>File Detail</h3>
+          <label>
+            File ID
+            <input value={fileId} onChange={(event) => setFileId(event.target.value)} />
+          </label>
+          <button onClick={handleGetFile}>Get File</button>
+          <ResultBlock title="File Detail Response" value={fileDetailResult} />
+        </div>
+
+        <div className="card">
+          <h3>Report Job Create</h3>
+          <label>
+            Report Type
+            <input value={reportType} onChange={(event) => setReportType(event.target.value)} />
+          </label>
+          <label>
+            Requested By
+            <input
+              value={requestedByMemberId}
+              onChange={(event) => setRequestedByMemberId(event.target.value)}
+            />
+          </label>
+          <button onClick={handleCreateReportJob}>Create Job</button>
+          <ResultBlock title="Report Create Response" value={reportCreateResult} />
+        </div>
+
+        <div className="card">
+          <h3>Report Job Detail</h3>
+          <label>
+            Job ID
+            <input value={jobId} onChange={(event) => setJobId(event.target.value)} />
+          </label>
+          <button onClick={handleGetReportJob}>Get Job</button>
+          <ResultBlock title="Report Detail Response" value={reportDetailResult} />
+        </div>
+      </div>
+
+      {!accessToken ? (
+        <p className="warningBanner">
+          Inventory, file, and report requests are expected to run with a gateway token. Login in
+          the Auth panel first for realistic authorization behavior.
+        </p>
+      ) : null}
+
+      {errorText ? <p className="errorBanner">{errorText}</p> : null}
+    </section>
+  );
+}
+
+function ResultBlock({ title, value }: { title: string; value: unknown }) {
+  return (
+    <details className="resultBlock">
+      <summary>{title}</summary>
+      <pre>{JSON.stringify(value, null, 2)}</pre>
+    </details>
+  );
+}

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -130,6 +130,66 @@ export type QualityDocumentAckResponse = {
   duplicateRequest?: boolean;
 };
 
+export type InventoryBalance = {
+  itemCode: string;
+  warehouseCode: string;
+  quantity: number;
+  updatedAt: string;
+};
+
+export type InventoryMovement = {
+  movementId: string;
+  itemCode: string;
+  warehouseCode: string;
+  movementType: string;
+  quantity: number;
+  referenceNo?: string;
+  movedAt: string;
+};
+
+export type InventoryBalanceSearchResponse = {
+  items: InventoryBalance[];
+  total: number;
+  page: number;
+  size: number;
+};
+
+export type InventoryMovementSearchResponse = {
+  items: InventoryMovement[];
+  total: number;
+  page: number;
+  size: number;
+};
+
+export type FileRegisterRequest = {
+  domainKey: string;
+  originalName: string;
+  storagePath: string;
+};
+
+export type FileMetadata = {
+  fileId: string;
+  domainKey: string;
+  originalName: string;
+  storagePath: string;
+};
+
+export type ReportJobCreateRequest = {
+  reportType: string;
+  requestedByMemberId?: string;
+};
+
+export type ReportJob = {
+  jobId: string;
+  reportType: string;
+  status: string;
+  requestedByMemberId?: string;
+  requestedAt: string;
+  completedAt?: string | null;
+  outputFileId?: string | null;
+  errorMessage?: string | null;
+};
+
 export type OrderSummary = {
   orderId: string;
   supplierId: string;
@@ -376,6 +436,54 @@ export class ScmApiClient {
       `/api/quality-doc/v1/documents/${encodeURIComponent(documentId)}/ack`,
       request
     );
+  }
+
+  searchInventoryBalances(params: {
+    itemCode?: string;
+    warehouseCode?: string;
+    page?: number;
+    size?: number;
+  }): Promise<InventoryBalanceSearchResponse> {
+    const query = buildQueryString({
+      itemCode: params.itemCode,
+      warehouseCode: params.warehouseCode,
+      page: params.page,
+      size: params.size
+    });
+    return this.request<InventoryBalanceSearchResponse>("GET", `/api/inventory/v1/balances${query}`);
+  }
+
+  searchInventoryMovements(params: {
+    itemCode?: string;
+    warehouseCode?: string;
+    movementType?: string;
+    page?: number;
+    size?: number;
+  }): Promise<InventoryMovementSearchResponse> {
+    const query = buildQueryString({
+      itemCode: params.itemCode,
+      warehouseCode: params.warehouseCode,
+      movementType: params.movementType,
+      page: params.page,
+      size: params.size
+    });
+    return this.request<InventoryMovementSearchResponse>("GET", `/api/inventory/v1/movements${query}`);
+  }
+
+  registerFile(request: FileRegisterRequest): Promise<FileMetadata> {
+    return this.request<FileMetadata>("POST", "/api/file/v1/files", request);
+  }
+
+  getFile(fileId: string): Promise<FileMetadata> {
+    return this.request<FileMetadata>("GET", `/api/file/v1/files/${encodeURIComponent(fileId)}`);
+  }
+
+  createReportJob(request: ReportJobCreateRequest): Promise<ReportJob> {
+    return this.request<ReportJob>("POST", "/api/report/v1/jobs", request);
+  }
+
+  getReportJob(jobId: string): Promise<ReportJob> {
+    return this.request<ReportJob>("GET", `/api/report/v1/jobs/${encodeURIComponent(jobId)}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- implement Inventory balance/movement UI against the shared gateway client
- implement File metadata register/detail UI and Report job create/detail UI
- add requestedBy hint tracking and regression tests

## Validation
- frontend-build PASS
- frontend-unit-test PASS
- frontend-contract-test PASS
- frontend-e2e-smoke PASS
- frontend-security-scan PASS
- real gateway smoke PASS for inventory balances/movements, file register/detail, and report job create/detail

Depends on #75
Closes #76