### PR TITLE
feat(scm-250): implement integrated p0 runner and cutover references

### DIFF
--- a/doc/QnA_보고서.md
+++ b/doc/QnA_보고서.md
@@ -3005,3 +3005,63 @@ Java 21로 업그레이드(현재 17) 및 버전 고정 정책 적용
 - 결과:
   - `SCM-249` UI MVP는 프론트 게이트와 실제 gateway smoke 기준으로 구현 완료
   - 다음 단계는 `SCM-250` 통합 E2E + 컷오버 UI/런북 연계로 진입
+
+### Q165. SCM-250 통합 P0 runner + 컷오버 참조 패널 구현 및 전체 P0 smoke 통과 (2026-03-13)
+- 사용자 요청 맥락:
+  - `SCM-248 -> SCM-249 -> SCM-250` 프론트 PR 라인 순차 진행
+- 수행 내용:
+  - 이슈/브랜치 생성:
+    - Issue `#78` 생성: `[SCM-250] Frontend integrated P0 runner + cutover references`
+    - 브랜치: `feature/scm-250-frontend-e2e-cutover`
+  - 프론트 변경:
+    - `frontend/apps/web-portal/src/features/cutover-runner-panel.tsx` 추가
+      - `Run P0 Gateway Scenario` 버튼으로 cross-domain gateway 호출을 순차 실행
+      - 포함 순서:
+        - token verify
+        - member search
+        - order/lot
+        - board
+        - quality-doc ACK
+        - inventory
+        - file register/detail
+        - report create/detail
+      - 컷오버/리허설 참조 경로 표시:
+        - `runbooks/rehearsal-R1-runbook.md`
+        - `runbooks/go-nogo-signoff.md`
+        - `runbooks/merge-gates-checklist.md`
+        - `runbooks/today-execution-R1.md`
+        - `doc/roadmap/scm-201-p0-scenarios.md`
+    - `frontend/apps/web-portal/src/features/cutover-runner-panel.test.ts` 추가
+      - scenario member fallback 테스트
+      - runbook reference 목록 테스트
+    - `frontend/apps/web-portal/src/App.tsx`
+      - hero 문구를 integrated runner 기준으로 확장
+      - `CutoverRunnerPanel` 연결
+    - `frontend/apps/web-portal/src/styles.css`
+      - disabled button / reference list 스타일 추가
+  - 프론트 게이트:
+    - `frontend-build` PASS
+    - `frontend-unit-test` PASS
+    - `frontend-contract-test` PASS
+    - `frontend-e2e-smoke` PASS
+    - `frontend-security-scan` PASS
+  - 통합 P0 실측:
+    - `powershell -ExecutionPolicy Bypass -File .\scripts\smoke-gateway-p0-e2e.ps1` 실행
+    - health:
+      - auth/member/board/quality-doc/order-lot/inventory/file/report/gateway 전부 `UP`
+    - 결과:
+      - `P0-F01` login + token verify + member search/detail PASS
+      - `P0-F02` order/lot flow PASS
+      - `P0-F03` file register/get PASS
+      - `P0-F04` board list/detail PASS
+      - `P0-F05` quality-doc list/detail/ack PASS
+      - `P0-F06` inventory balances/movements PASS
+      - `P0-F07` report create/get PASS
+      - 최종: `P0-F01~F07 gateway E2E smoke passed`
+- 산출물/근거:
+  - `scripts/smoke-gateway-p0-e2e.ps1` PASS 로그
+  - `runbooks/evidence/SCM-248-*`
+  - `runbooks/evidence/SCM-249-*`
+- 결과:
+  - 프론트 PR 라인 `SCM-248`, `SCM-249`, `SCM-250` 구현이 모두 완료됨
+  - 남은 작업은 각 PR 체크/리뷰/머지와 기준 브랜치 rebase 정리

--- a/frontend/apps/web-portal/src/App.tsx
+++ b/frontend/apps/web-portal/src/App.tsx
@@ -3,6 +3,7 @@ import { describePortalScope } from "@scm-rft/ui";
 import { readContractCatalog } from "@scm-rft/api-client";
 import { AuthMemberPanel } from "./features/auth-member-panel";
 import { BoardQualityDocPanel } from "./features/board-qualitydoc-panel";
+import { CutoverRunnerPanel } from "./features/cutover-runner-panel";
 import { InventoryFileReportPanel } from "./features/inventory-file-report-panel";
 import { OrderLotPanel } from "./features/order-lot-panel";
 
@@ -44,8 +45,8 @@ export default function App() {
         <h1>{title}</h1>
         <p className="heroText">
           The portal now covers Auth, Member, Board, Quality-Doc, Inventory, File, Report, and
-          Order-Lot MVP paths so the main P0 workflows can be exercised against the gateway from
-          one surface.
+          Order-Lot MVP paths, plus an integrated P0 runner so the main gateway workflow can be
+          exercised from one surface.
         </p>
         <div className="heroMeta">
           <span>Contracts: {catalog.contracts.length}</span>
@@ -85,6 +86,12 @@ export default function App() {
         apiBaseUrl={orderLotApiBaseUrl}
         accessToken={accessToken}
         changedByHint={currentMemberId}
+      />
+
+      <CutoverRunnerPanel
+        apiBaseUrl={apiBaseUrl}
+        accessToken={accessToken}
+        memberIdHint={currentMemberId}
       />
     </main>
   );

--- a/frontend/apps/web-portal/src/features/cutover-runner-panel.test.ts
+++ b/frontend/apps/web-portal/src/features/cutover-runner-panel.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildRunbookReferences, pickScenarioMemberId } from "./cutover-runner-panel";
+
+describe("pickScenarioMemberId", () => {
+  it("uses the hinted member when present", () => {
+    expect(pickScenarioMemberId("smoke-admin")).toBe("smoke-admin");
+  });
+
+  it("falls back to smoke-user when no hint exists", () => {
+    expect(pickScenarioMemberId("")).toBe("smoke-user");
+  });
+});
+
+describe("buildRunbookReferences", () => {
+  it("keeps the cutover reference list stable", () => {
+    expect(buildRunbookReferences()).toContain("runbooks/go-nogo-signoff.md");
+    expect(buildRunbookReferences()).toContain("doc/roadmap/scm-201-p0-scenarios.md");
+  });
+});

--- a/frontend/apps/web-portal/src/features/cutover-runner-panel.tsx
+++ b/frontend/apps/web-portal/src/features/cutover-runner-panel.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import { createScmApiClient, formatApiError } from "@scm-rft/api-client";
+
+type CutoverRunnerPanelProps = {
+  apiBaseUrl: string;
+  accessToken: string;
+  memberIdHint?: string;
+};
+
+export function pickScenarioMemberId(memberIdHint?: string) {
+  return memberIdHint?.trim() ? memberIdHint.trim() : "smoke-user";
+}
+
+export function buildRunbookReferences() {
+  return [
+    "runbooks/rehearsal-R1-runbook.md",
+    "runbooks/go-nogo-signoff.md",
+    "runbooks/merge-gates-checklist.md",
+    "runbooks/today-execution-R1.md",
+    "doc/roadmap/scm-201-p0-scenarios.md"
+  ];
+}
+
+export function CutoverRunnerPanel({
+  apiBaseUrl,
+  accessToken,
+  memberIdHint = ""
+}: CutoverRunnerPanelProps) {
+  const [errorText, setErrorText] = useState("");
+  const [scenarioResult, setScenarioResult] = useState<unknown>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const scenarioMemberId = pickScenarioMemberId(memberIdHint);
+  const runbookReferences = buildRunbookReferences();
+
+  async function handleRunScenario() {
+    if (!accessToken) {
+      setErrorText("Run the Auth login flow first so the integrated scenario has a gateway token.");
+      return;
+    }
+
+    setIsRunning(true);
+    setErrorText("");
+
+    try {
+      const client = createScmApiClient({ baseUrl: apiBaseUrl, accessToken });
+      const summary: Record<string, unknown> = {
+        memberId: scenarioMemberId
+      };
+
+      const verify = await client.verifyToken(accessToken);
+      summary.tokenActive = verify.active;
+
+      const members = await client.searchMembers({
+        keyword: scenarioMemberId,
+        status: "ACTIVE",
+        page: 0,
+        size: 10
+      });
+      summary.memberHits = members.items.length;
+
+      const orders = await client.searchOrders({
+        keyword: "P0-ORDER",
+        page: 0,
+        size: 10
+      });
+      const orderId = orders.items[0]?.orderId ?? "P0-ORDER-001";
+      summary.orderId = orderId;
+
+      const orderDetail = await client.getOrder(orderId);
+      summary.orderStatus = orderDetail.status;
+
+      const lotDetail = await client.getLot("P0-LOT-001");
+      summary.lotId = lotDetail.lotId;
+
+      const boardPosts = await client.searchBoardPosts({ page: 0, size: 10 });
+      const boardPostId = boardPosts.items[0]?.postId;
+      summary.boardPostCount = boardPosts.items.length;
+      if (boardPostId) {
+        const boardDetail = await client.getBoardPost(boardPostId);
+        summary.boardPostId = boardDetail.postId;
+      }
+
+      const qualityDocs = await client.searchQualityDocuments({ page: 0, size: 10 });
+      const documentId = qualityDocs.items[0]?.documentId ?? "11111111-1111-1111-1111-111111111111";
+      summary.qualityDocCount = qualityDocs.items.length;
+      const qualityDetail = await client.getQualityDocument(documentId);
+      summary.qualityDocId = qualityDetail.documentId;
+      const ack = await client.acknowledgeQualityDocument(documentId, {
+        memberId: scenarioMemberId,
+        ackType: "READ",
+        comment: "SCM-250 integrated runner"
+      });
+      summary.qualityDocAcked = ack.acknowledged;
+      summary.qualityDocAckDuplicate = ack.duplicateRequest ?? false;
+
+      const balances = await client.searchInventoryBalances({
+        itemCode: "ITEM-001",
+        page: 0,
+        size: 10
+      });
+      summary.inventoryBalanceCount = balances.items.length;
+
+      const fileMetadata = await client.registerFile({
+        domainKey: "P0:CUTOVER",
+        originalName: "scm-250-proof.txt",
+        storagePath: "frontend/scm-250-proof.txt"
+      });
+      summary.fileId = fileMetadata.fileId;
+      const fileDetail = await client.getFile(fileMetadata.fileId);
+      summary.fileDetailId = fileDetail.fileId;
+
+      const reportJob = await client.createReportJob({
+        reportType: "P0_DAILY",
+        requestedByMemberId: scenarioMemberId
+      });
+      summary.reportJobId = reportJob.jobId;
+      const reportDetail = await client.getReportJob(reportJob.jobId);
+      summary.reportStatus = reportDetail.status;
+
+      setScenarioResult(summary);
+    } catch (error) {
+      setErrorText(formatApiError(error));
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  return (
+    <section className="panel">
+      <div className="panelHeader">
+        <p className="eyebrow">SCM-250</p>
+        <h2>Integrated P0 Runner + Cutover References</h2>
+        <p className="panelIntro">
+          This panel runs the cross-domain gateway scenario in one shot and keeps the cutover
+          runbook references visible inside the portal while the frontend line is hardened.
+        </p>
+      </div>
+
+      <div className="actionGrid">
+        <div className="card">
+          <h3>Run P0 Gateway Scenario</h3>
+          <p className="hintText">
+            Sequence: token verify, member search, order/lot, board, quality-doc ACK, inventory,
+            file register/detail, report job create/detail.
+          </p>
+          <p className="hintText">Scenario member: {scenarioMemberId}</p>
+          <button onClick={handleRunScenario} disabled={isRunning}>
+            {isRunning ? "Running..." : "Run P0 Gateway Scenario"}
+          </button>
+          <ResultBlock title="Scenario Summary" value={scenarioResult} />
+        </div>
+
+        <div className="card">
+          <h3>Cutover References</h3>
+          <ul className="referenceList">
+            {runbookReferences.map((path) => (
+              <li key={path}>
+                <code>{path}</code>
+              </li>
+            ))}
+          </ul>
+          <p className="hintText">
+            Use these files for rehearsal timing, merge gates, and final Go/No-Go signoff.
+          </p>
+        </div>
+      </div>
+
+      {errorText ? <p className="errorBanner">{errorText}</p> : null}
+    </section>
+  );
+}
+
+function ResultBlock({ title, value }: { title: string; value: unknown }) {
+  return (
+    <details className="resultBlock">
+      <summary>{title}</summary>
+      <pre>{JSON.stringify(value, null, 2)}</pre>
+    </details>
+  );
+}

--- a/frontend/apps/web-portal/src/styles.css
+++ b/frontend/apps/web-portal/src/styles.css
@@ -145,6 +145,11 @@ button {
   cursor: pointer;
 }
 
+button:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
 .ghostButton {
   color: #163556;
   background: rgba(22, 53, 86, 0.08);
@@ -203,6 +208,17 @@ button {
 
 .hintText {
   margin: 0;
+  font-size: 0.92rem;
+}
+
+.referenceList {
+  margin: 0;
+  padding-left: 18px;
+  color: #31485e;
+  line-height: 1.6;
+}
+
+.referenceList code {
   font-size: 0.92rem;
 }
 


### PR DESCRIPTION
## Summary
- add integrated P0 gateway scenario runner to the web portal
- surface cutover and rehearsal reference links in the frontend shell
- supersedes closed stacked PR #79

## Validation
- frontend-build PASS
- frontend-unit-test PASS

Closes #78